### PR TITLE
Check constraints for .NET validation attributes

### DIFF
--- a/EFCore.CheckConstraints.Test/ValidationCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/ValidationCheckConstraintTest.cs
@@ -1,0 +1,161 @@
+using System.ComponentModel.DataAnnotations;
+using EFCore.CheckConstraints.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EFCore.CheckConstraints.Test
+{
+    public class ValidationCheckConstraintTest
+    {
+        [Fact]
+        public virtual void Range()
+        {
+            var builder = CreateBuilder();
+            builder.Entity<Blog>();
+
+            var model = builder.FinalizeModel();
+
+            var checkConstraint = Assert.Single(
+                model.FindEntityType(typeof(Blog)).GetCheckConstraints(),
+                c => c.Name == "CK_Blog_Rating_Range");
+            Assert.NotNull(checkConstraint);
+            Assert.Equal("[Rating] >= 1 AND [Rating] <= 5", checkConstraint.Sql);
+        }
+
+        [Fact]
+        public void MinLength()
+        {
+            var builder = CreateBuilder();
+            builder.Entity<Blog>();
+
+            var model = builder.FinalizeModel();
+
+            var checkConstraint = Assert.Single(
+                model.FindEntityType(typeof(Blog)).GetCheckConstraints(),
+                c => c.Name == "CK_Blog_Name_MinLength");
+            Assert.NotNull(checkConstraint);
+            Assert.Equal("LEN([Name]) >= 4", checkConstraint.Sql);
+        }
+
+        [Fact]
+        public virtual void Phone()
+        {
+            var builder = CreateBuilder();
+            builder.Entity<Blog>();
+
+            var model = builder.FinalizeModel();
+
+            var checkConstraint = Assert.Single(
+                model.FindEntityType(typeof(Blog)).GetCheckConstraints(),
+                c => c.Name == "CK_Blog_PhoneNumber_Phone");
+            Assert.NotNull(checkConstraint);
+            Assert.Equal(
+                $"dbo.RegexMatch('{ValidationCheckConstraintConvention.DefaultPhoneRegex}', [PhoneNumber])",
+                checkConstraint.Sql);
+        }
+
+        [Fact]
+        public virtual void CreditCard()
+        {
+            var builder = CreateBuilder();
+            builder.Entity<Blog>();
+
+            var model = builder.FinalizeModel();
+
+            var checkConstraint = Assert.Single(
+                model.FindEntityType(typeof(Blog)).GetCheckConstraints(),
+                c => c.Name == "CK_Blog_CreditCard_CreditCard");
+            Assert.NotNull(checkConstraint);
+            Assert.Equal(
+                $"dbo.RegexMatch('{ValidationCheckConstraintConvention.DefaultCreditCardRegex}', [CreditCard])",
+                checkConstraint.Sql);
+        }
+
+        [Fact]
+        public virtual void EmailAddress()
+        {
+            var builder = CreateBuilder();
+            builder.Entity<Blog>();
+
+            var model = builder.FinalizeModel();
+
+            var checkConstraint = Assert.Single(
+                model.FindEntityType(typeof(Blog)).GetCheckConstraints(),
+                c => c.Name == "CK_Blog_Email_EmailAddress");
+            Assert.NotNull(checkConstraint);
+            Assert.Equal(
+                $"dbo.RegexMatch('{ValidationCheckConstraintConvention.DefaultEmailAddressRegex}', [Email])",
+                checkConstraint.Sql);
+        }
+
+        [Fact]
+        public virtual void Url()
+        {
+            var builder = CreateBuilder();
+            builder.Entity<Blog>();
+
+            var model = builder.FinalizeModel();
+
+            var checkConstraint = Assert.Single(
+                model.FindEntityType(typeof(Blog)).GetCheckConstraints(),
+                c => c.Name == "CK_Blog_Address_Url");
+            Assert.NotNull(checkConstraint);
+            Assert.Equal(
+                $"dbo.RegexMatch('{ValidationCheckConstraintConvention.DefaultUrlAddressRegex}', [Address])",
+                checkConstraint.Sql);
+        }
+
+        [Fact]
+        public virtual void RegularExpression()
+        {
+            var builder = CreateBuilder();
+            builder.Entity<Blog>();
+
+            var model = builder.FinalizeModel();
+
+            var checkConstraint = Assert.Single(
+                model.FindEntityType(typeof(Blog)).GetCheckConstraints(),
+                c => c.Name == "CK_Blog_StartsWithA_RegularExpression");
+            Assert.NotNull(checkConstraint);
+            Assert.Equal("dbo.RegexMatch('^A', [StartsWithA])", checkConstraint.Sql);
+        }
+
+        class Blog
+        {
+            public int Id { get; set; }
+            [Range(1, 5)]
+            public int Rating { get; set; }
+            [MinLength(4)]
+            public string Name { get; set; }
+            [Phone]
+            public string PhoneNumber { get; set; }
+            [CreditCard]
+            public string CreditCard { get; set; }
+            [EmailAddress]
+            public string Email { get; set; }
+            [Url]
+            public string Address { get; set; }
+            [RegularExpression("^A")]
+            public string StartsWithA { get; set; }
+        }
+
+        private ModelBuilder CreateBuilder()
+        {
+            var serviceProvider = SqlServerTestHelpers.Instance.CreateContextServices();
+            var conventionSet = serviceProvider.GetRequiredService<IConventionSetBuilder>().CreateConventionSet();
+
+            conventionSet.ModelFinalizingConventions.Add(
+                new ValidationCheckConstraintConvention(
+                    new ValidationCheckConstraintOptions(),
+                    serviceProvider.GetRequiredService<ISqlGenerationHelper>(),
+                    serviceProvider.GetRequiredService<IRelationalTypeMappingSource>(),
+                    serviceProvider.GetRequiredService<IDatabaseProvider>()));
+
+            return new ModelBuilder(conventionSet);
+        }
+    }
+}

--- a/EFCore.CheckConstraints.Test/ValidationRegexTest.cs
+++ b/EFCore.CheckConstraints.Test/ValidationRegexTest.cs
@@ -1,0 +1,107 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using EFCore.CheckConstraints.Internal;
+using Xunit;
+
+namespace EFCore.CheckConstraints.Test
+{
+    // https://github.com/dotnet/runtime/blob/33dba9518b4eb7fbc487fadc9718c408f95a826c/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/PhoneAttributeTests.cs
+    public class ValidationRegexTest
+    {
+        [Theory]
+        [InlineData("425-555-1212")]
+        [InlineData("+1 425-555-1212")]
+        [InlineData("(425)555-1212")]
+        [InlineData("+44 (3456)987654")]
+        [InlineData("+777.456.789.123")]
+        [InlineData("425-555-1212 x123")]
+        [InlineData("425-555-1212 x 123")]
+        [InlineData("425-555-1212 ext123")]
+        [InlineData("425-555-1212 ext 123")]
+        [InlineData("425-555-1212 ext.123")]
+        [InlineData("425-555-1212 ext. 123")]
+        [InlineData("1")]
+        [InlineData("+4+2+5+-+5+5+5+-+1+2++1+2++")]
+        [InlineData("425-555-1212    ")]
+        [InlineData(" \r \n 1  \t ")]
+        [InlineData("1-.()")]
+        [InlineData("(425555-1212")]
+        [InlineData(")425555-1212")]
+        public virtual void Phone_valid(string phone)
+            => Assert.Matches(ValidationCheckConstraintConvention.DefaultPhoneRegex, phone);
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("abcdefghij")]
+        [InlineData("425-555-1212 ext 123 ext 456")]
+        [InlineData("425-555-1212 x")]
+        [InlineData("425-555-1212 ext")]
+        [InlineData("425-555-1212 ext.")]
+        [InlineData("425-555-1212 x abc")]
+        [InlineData("425-555-1212 ext def")]
+        [InlineData("425-555-1212 ext. xyz")]
+        [InlineData("-.()")]
+        [InlineData("ext.123 1")]
+        public virtual void Phone_invalid(string phone)
+            => Assert.DoesNotMatch(ValidationCheckConstraintConvention.DefaultPhoneRegex, phone);
+
+        [Theory]
+        [InlineData("0000000000000000")]
+        [InlineData("1234567890123452")]
+        [InlineData("  1 2 3 4 5 6 7 8 9 0  1 2 34 5 2    ")]
+        [InlineData("--1-2-3-4-5-6-7-8-9-0--1-2-34-5-2----")]
+        [InlineData(" - 1- -  2 3 --4 5 6 7 -8- -9- -0 - -1 -2 -3-4- --5-- 2    ")]
+        [InlineData("1234-5678-9012-3452")]
+        [InlineData("1234 5678 9012 3452")]
+        public virtual void CreditCard_valid(string creditCard)
+            => Assert.Matches(ValidationCheckConstraintConvention.DefaultCreditCardRegex, creditCard);
+
+        [Theory]
+        [InlineData("000%000000000001")]
+        [InlineData("1234567890123452a")]
+        [InlineData("1234567890123452\0")]
+        public virtual void CreditCard_invalid(string creditCard)
+            => Assert.DoesNotMatch(ValidationCheckConstraintConvention.DefaultCreditCardRegex, creditCard);
+
+        [Theory]
+        [InlineData("someName@someDomain.com")]
+        [InlineData("1234@someDomain.com")]
+        [InlineData("firstName.lastName@someDomain.com")]
+        [InlineData("\u00A0@someDomain.com")]
+        [InlineData("!#$%&'*+-/=?^_`|~@someDomain.com")]
+        [InlineData("\"firstName.lastName\"@someDomain.com")]
+        [InlineData("someName@some~domain.com")]
+        [InlineData("someName@some_domain.com")]
+        [InlineData("someName@1234.com")]
+        [InlineData("someName@someDomain\uFFEF.com")]
+        public virtual void EmailAddress_valid(string emailAddress)
+            => Assert.Matches(ValidationCheckConstraintConvention.DefaultEmailAddressRegex, emailAddress);
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("")]
+        [InlineData(" \r \t \n" )]
+        [InlineData("@someDomain.com")]
+        [InlineData("@someDomain@abc.com")]
+        [InlineData("someName")]
+        [InlineData("someName@")]
+        [InlineData("someName@a@b.com")]
+        public virtual void EmailAddress_invalid(string emailAddress)
+            => Assert.DoesNotMatch(ValidationCheckConstraintConvention.DefaultEmailAddressRegex, emailAddress);
+
+        [Theory]
+        [InlineData("http://foo.bar")]
+        [InlineData("https://foo.bar")]
+        [InlineData("ftp://foo.bar")]
+        public virtual void Url_valid(string url)
+            => Assert.Matches(ValidationCheckConstraintConvention.DefaultUrlAddressRegex, url);
+
+        [Theory]
+        [InlineData("file:///foo.bar")]
+        [InlineData("foo.png")]
+        [InlineData("")]
+        public virtual void Url_invalid(string url)
+            => Assert.DoesNotMatch(ValidationCheckConstraintConvention.DefaultUrlAddressRegex, url);
+    }
+}

--- a/EFCore.CheckConstraints.sln.DotSettings
+++ b/EFCore.CheckConstraints.sln.DotSettings
@@ -215,6 +215,7 @@ Licensed under the Apache License, Version 2.0. See License.txt in the project r
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=materializer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=materializers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=navigations/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pomelo/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pushdown/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=remapper/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=requiredness/@EntryIndexedValue">True</s:Boolean>

--- a/EFCore.CheckConstraints/CheckConstraintsExtensions.cs
+++ b/EFCore.CheckConstraints/CheckConstraintsExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using JetBrains.Annotations;
@@ -34,11 +35,29 @@ namespace Microsoft.EntityFrameworkCore
             return optionsBuilder;
         }
 
+        public static DbContextOptionsBuilder UseValidationCheckConstraints(
+            [NotNull] this DbContextOptionsBuilder optionsBuilder,
+            [CanBeNull] Action<ValidationCheckConstraintOptionsBuilder> validationCheckConstraintsOptionsAction = null)
+        {
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+
+            var validationCheckConstraintsOptionsBuilder = new ValidationCheckConstraintOptionsBuilder();
+            validationCheckConstraintsOptionsAction?.Invoke(validationCheckConstraintsOptionsBuilder);
+
+            var extension = (optionsBuilder.Options.FindExtension<CheckConstraintsOptionsExtension>() ?? new CheckConstraintsOptionsExtension())
+                .WithValidationCheckConstraintsOptions(validationCheckConstraintsOptionsBuilder.Options);
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+            return optionsBuilder;
+        }
+
         public static DbContextOptionsBuilder UseAllCheckConstraints(
             [NotNull] this DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
                 .UseEnumCheckConstraints()
-                .UseDiscriminatorCheckConstraints();
+                .UseDiscriminatorCheckConstraints()
+                .UseValidationCheckConstraints();
 
         public static DbContextOptionsBuilder<TContext> UseEnumCheckConstraints<TContext>([NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder)
             where TContext : DbContext
@@ -47,5 +66,11 @@ namespace Microsoft.EntityFrameworkCore
         public static DbContextOptionsBuilder<TContext> UseDiscriminatorCheckConstraints<TContext>([NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder)
             where TContext : DbContext
             => (DbContextOptionsBuilder<TContext>)UseDiscriminatorCheckConstraints((DbContextOptionsBuilder)optionsBuilder);
+
+        public static DbContextOptionsBuilder<TContext> UseValidationCheckConstraints<TContext>(
+            [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
+            [CanBeNull] Action<ValidationCheckConstraintOptionsBuilder> validationCheckConstraintsOptionsAction = null)
+            where TContext : DbContext
+            => (DbContextOptionsBuilder<TContext>)UseValidationCheckConstraints((DbContextOptionsBuilder)optionsBuilder, validationCheckConstraintsOptionsAction);
     }
 }

--- a/EFCore.CheckConstraints/CodeAnnotations.cs
+++ b/EFCore.CheckConstraints/CodeAnnotations.cs
@@ -105,4 +105,10 @@ namespace JetBrains.Annotations
         Members = 2,
         WithMembers = Itself | Members
     }
+
+    /// <summary>
+    /// Indicates that the marked parameter is a regular expression pattern.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property)]
+    internal sealed class RegexPatternAttribute : Attribute { }
 }

--- a/EFCore.CheckConstraints/Internal/CheckConstraintsConventionSetPlugin.cs
+++ b/EFCore.CheckConstraints/Internal/CheckConstraintsConventionSetPlugin.cs
@@ -10,13 +10,19 @@ namespace EFCore.CheckConstraints.Internal
     {
         private readonly IDbContextOptions _options;
         private readonly ISqlGenerationHelper _sqlGenerationHelper;
+        private readonly IRelationalTypeMappingSource _relationalTypeMappingSource;
+        private readonly IDatabaseProvider _databaseProvider;
 
         public CheckConstraintsConventionSetPlugin(
             [NotNull] IDbContextOptions options,
-            ISqlGenerationHelper sqlGenerationHelper)
+            ISqlGenerationHelper sqlGenerationHelper,
+            IRelationalTypeMappingSource relationalTypeMappingSource,
+            IDatabaseProvider databaseProvider)
         {
             _options = options;
             _sqlGenerationHelper = sqlGenerationHelper;
+            _relationalTypeMappingSource = relationalTypeMappingSource;
+            _databaseProvider = databaseProvider;
         }
 
         public ConventionSet ModifyConventions(ConventionSet conventionSet)
@@ -25,12 +31,21 @@ namespace EFCore.CheckConstraints.Internal
 
             if (extension.AreEnumCheckConstraintsEnabled)
             {
-                conventionSet.ModelFinalizingConventions.Add(new EnumCheckConstraintConvention(_sqlGenerationHelper));
+                conventionSet.ModelFinalizingConventions.Add(
+                    new EnumCheckConstraintConvention(_sqlGenerationHelper));
             }
 
             if (extension.AreDiscriminatorCheckConstraintsEnabled)
             {
-                conventionSet.ModelFinalizingConventions.Add(new DiscriminatorCheckConstraintConvention(_sqlGenerationHelper));
+                conventionSet.ModelFinalizingConventions.Add(
+                    new DiscriminatorCheckConstraintConvention(_sqlGenerationHelper));
+            }
+
+            if (extension.AreValidationCheckConstraintsEnabled)
+            {
+                conventionSet.ModelFinalizingConventions.Add(
+                    new ValidationCheckConstraintConvention(
+                        extension.ValidationCheckConstraintOptions, _sqlGenerationHelper, _relationalTypeMappingSource, _databaseProvider));
             }
 
             return conventionSet;

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
@@ -1,0 +1,260 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace EFCore.CheckConstraints.Internal
+{
+    /// <summary>
+    ///     A convention that creates check constraints for various validation attributes.
+    /// </summary>
+    public class ValidationCheckConstraintConvention : IModelFinalizingConvention
+    {
+        public const string DefaultPhoneRegex = @"^[\d\s+-.()]*\d[\d\s+-.()]*((ext\.|ext|x)\s*\d+)?\s*$";
+        public const string DefaultCreditCardRegex = @"^[\d- ]*$";
+        public const string DefaultEmailAddressRegex = @"^[^@]+@[^@]+$";
+        public const string DefaultUrlAddressRegex = @"^(http://|https://|ftp://)";
+
+        private readonly ISqlGenerationHelper _sqlGenerationHelper;
+        private readonly IDatabaseProvider _databaseProvider;
+        private readonly RelationalTypeMapping _intTypeMapping;
+
+        private readonly bool _supportsRegex;
+        private readonly string _phoneRegex, _creditCardRegex, _emailAddressRegex, _urlRegex;
+
+        public ValidationCheckConstraintConvention(
+            ValidationCheckConstraintOptions options,
+            ISqlGenerationHelper sqlGenerationHelper,
+            IRelationalTypeMappingSource relationalTypeMappingSource,
+            IDatabaseProvider databaseProvider)
+        {
+            _sqlGenerationHelper = sqlGenerationHelper;
+            _databaseProvider = databaseProvider;
+            _intTypeMapping = relationalTypeMappingSource.FindMapping(typeof(int));
+
+            _supportsRegex = SupportsRegex;
+            _phoneRegex = options.PhoneRegex ?? DefaultPhoneRegex;
+            _creditCardRegex = options.CreditCardRegex ?? DefaultCreditCardRegex;
+            _emailAddressRegex = options.EmailAddressRegex ?? DefaultEmailAddressRegex;
+            _urlRegex = options.UrlRegex ?? DefaultUrlAddressRegex;
+        }
+
+        /// <inheritdoc />
+        public virtual void ProcessModelFinalizing(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
+        {
+            var sql = new StringBuilder();
+
+            foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
+            {
+                var tableName = entityType.GetTableName();
+                if (tableName is null)
+                {
+                    continue;
+                }
+
+                foreach (var property in entityType.GetDeclaredProperties().Where(p => p.PropertyInfo != null || p.FieldInfo != null))
+                {
+                    var memberInfo = (MemberInfo)property.PropertyInfo ?? property.FieldInfo;
+                    if (memberInfo is null)
+                    {
+                        continue;
+                    }
+
+                    var columnName = property.GetColumnName();
+                    if (columnName is null)
+                    {
+                        continue;
+                    }
+
+                    ProcessRange(property, memberInfo, tableName, columnName, sql);
+                    ProcessMinLength(property, memberInfo, tableName, columnName, sql);
+
+                    if (_supportsRegex)
+                    {
+                        ProcessPhoneNumber(property, memberInfo, tableName, columnName, sql);
+                        ProcessCreditCard(property, memberInfo, tableName, columnName, sql);
+                        ProcessEmailAddress(property, memberInfo, tableName, columnName, sql);
+                        ProcessUrl(property, memberInfo, tableName, columnName, sql);
+                        ProcessRegularExpression(property, memberInfo, tableName, columnName, sql);
+                    }
+                }
+            }
+        }
+
+        protected virtual void ProcessRange(
+            IConventionProperty property,
+            MemberInfo memberInfo,
+            string tableName,
+            string columnName,
+            StringBuilder sql)
+        {
+            if (!(memberInfo.GetCustomAttribute<RangeAttribute>() is RangeAttribute attribute)
+                || !(property.FindTypeMapping() is RelationalTypeMapping typeMapping)
+                || attribute.Minimum.GetType() != typeMapping.ClrType
+                || attribute.Maximum.GetType() != typeMapping.ClrType)
+            {
+                return;
+            }
+
+            sql.Clear();
+
+            sql
+                .Append(_sqlGenerationHelper.DelimitIdentifier(columnName))
+                .Append(" >= ")
+                .Append(typeMapping.GenerateSqlLiteral(attribute.Minimum))
+                .Append(" AND ")
+                .Append(_sqlGenerationHelper.DelimitIdentifier(columnName))
+                .Append(" <= ")
+                .Append(typeMapping.GenerateSqlLiteral(attribute.Maximum));
+
+            var constraintName = $"CK_{tableName}_{columnName}_Range";
+            property.DeclaringEntityType.AddCheckConstraint(constraintName, sql.ToString());
+        }
+
+        protected virtual void ProcessMinLength(
+            IConventionProperty property,
+            MemberInfo memberInfo,
+            string tableName,
+            string columnName,
+            StringBuilder sql)
+        {
+            if (_intTypeMapping is null ||
+                !(memberInfo.GetCustomAttribute<MinLengthAttribute>()?.Length is int minLength))
+            {
+                return;
+            }
+
+            var lengthFunctionName = _databaseProvider.Name switch
+            {
+                "Microsoft.EntityFrameworkCore.SqlServer" => "LEN",
+                "Microsoft.EntityFrameworkCore.Sqlite" => "LENGTH",
+                "Npgsql.EntityFrameworkCore.PostgreSQL" => "LENGTH",
+                "Pomelo.EntityFrameworkCore.MySQL" => "LENGTH",
+                _ => null
+            };
+
+            if (lengthFunctionName is null)
+            {
+                return;
+            }
+
+            sql.Clear();
+
+            sql
+                .Append(lengthFunctionName)
+                .Append('(')
+                .Append(_sqlGenerationHelper.DelimitIdentifier(columnName))
+                .Append(')')
+                .Append(" >= ")
+                .Append(_intTypeMapping.GenerateSqlLiteral(minLength));
+
+            var constraintName = $"CK_{tableName}_{columnName}_MinLength";
+            property.DeclaringEntityType.AddCheckConstraint(constraintName, sql.ToString());
+        }
+
+        protected virtual void ProcessPhoneNumber(
+            IConventionProperty property,
+            MemberInfo memberInfo,
+            string tableName,
+            string columnName,
+            StringBuilder sql)
+        {
+            if (memberInfo.GetCustomAttribute<PhoneAttribute>() != null)
+            {
+                property.DeclaringEntityType.AddCheckConstraint(
+                    $"CK_{tableName}_{columnName}_Phone",
+                    GenerateRegexSql(columnName, _phoneRegex));
+            }
+        }
+
+        protected virtual void ProcessCreditCard(
+            IConventionProperty property,
+            MemberInfo memberInfo,
+            string tableName,
+            string columnName,
+            StringBuilder sql)
+        {
+            if (memberInfo.GetCustomAttribute<CreditCardAttribute>() != null)
+            {
+                property.DeclaringEntityType.AddCheckConstraint(
+                    $"CK_{tableName}_{columnName}_CreditCard",
+                    GenerateRegexSql(columnName, _creditCardRegex));
+            }
+        }
+
+        protected virtual void ProcessEmailAddress(
+            IConventionProperty property,
+            MemberInfo memberInfo,
+            string tableName,
+            string columnName,
+            StringBuilder sql)
+        {
+            if (memberInfo.GetCustomAttribute<EmailAddressAttribute>() != null)
+            {
+                property.DeclaringEntityType.AddCheckConstraint(
+                    $"CK_{tableName}_{columnName}_EmailAddress",
+                    GenerateRegexSql(columnName, _emailAddressRegex));
+            }
+        }
+
+        protected virtual void ProcessUrl(
+            IConventionProperty property,
+            MemberInfo memberInfo,
+            string tableName,
+            string columnName,
+            StringBuilder sql)
+        {
+            if (memberInfo.GetCustomAttribute<UrlAttribute>() != null)
+            {
+                property.DeclaringEntityType.AddCheckConstraint(
+                    $"CK_{tableName}_{columnName}_Url",
+                    GenerateRegexSql(columnName, _urlRegex));
+            }
+        }
+
+        protected virtual void ProcessRegularExpression(
+            IConventionProperty property,
+            MemberInfo memberInfo,
+            string tableName,
+            string columnName,
+            StringBuilder sql)
+        {
+            if (memberInfo.GetCustomAttribute<RegularExpressionAttribute>()?.Pattern is string pattern)
+            {
+                property.DeclaringEntityType.AddCheckConstraint(
+                    $"CK_{tableName}_{columnName}_RegularExpression",
+                    GenerateRegexSql(columnName, pattern));
+            }
+        }
+
+        protected virtual string GenerateRegexSql(string columnName, [RegexPattern] string regex)
+            => string.Format(
+                _databaseProvider.Name switch
+                {
+                    // For SQL Server, requires setup:
+                    // https://www.red-gate.com/simple-talk/sql/t-sql-programming/tsql-regular-expression-workbench/
+                    "Microsoft.EntityFrameworkCore.SqlServer" => "dbo.RegexMatch('{1}', {0})",
+                    "Microsoft.EntityFrameworkCore.Sqlite" => "{0} REGEXP '{1}'",
+                    "Npgsql.EntityFrameworkCore.PostgreSQL" => "{0} ~ '{1}'",
+                    "Pomelo.EntityFrameworkCore.MySQL" => "{0} REGEXP '{1}'",
+                    _ => throw new InvalidOperationException($"Provider {_databaseProvider.Name} doesn't support regular expressions")
+                }, _sqlGenerationHelper.DelimitIdentifier(columnName), regex);
+
+        protected virtual bool SupportsRegex
+            => _databaseProvider.Name switch
+            {
+                "Microsoft.EntityFrameworkCore.SqlServer" => true,
+                "Microsoft.EntityFrameworkCore.Sqlite" => true,
+                "Npgsql.EntityFrameworkCore.PostgreSQL" => true,
+                "Pomelo.EntityFrameworkCore.MySQL" => true,
+                _ => false
+            };
+    }
+}

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
@@ -53,7 +53,7 @@ namespace EFCore.CheckConstraints.Internal
 
             foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
             {
-                var tableName = entityType.GetTableName();
+                var (tableName, schema) = (entityType.GetTableName(), entityType.GetSchema());
                 if (tableName is null)
                 {
                     continue;
@@ -67,7 +67,7 @@ namespace EFCore.CheckConstraints.Internal
                         continue;
                     }
 
-                    var columnName = property.GetColumnName();
+                    var columnName = property.GetColumnName(StoreObjectIdentifier.Table(tableName, schema));
                     if (columnName is null)
                     {
                         continue;

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptions.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptions.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace EFCore.CheckConstraints.Internal
+{
+    public class ValidationCheckConstraintOptions : IEquatable<ValidationCheckConstraintOptions>
+    {
+        public ValidationCheckConstraintOptions()
+        {
+        }
+
+        public ValidationCheckConstraintOptions(ValidationCheckConstraintOptions copyFrom)
+        {
+            PhoneRegex = copyFrom.PhoneRegex;
+            CreditCardRegex = copyFrom.CreditCardRegex;
+            EmailAddressRegex = copyFrom.EmailAddressRegex;
+            UrlRegex = copyFrom.UrlRegex;
+        }
+
+        public string PhoneRegex { get; set; }
+        public string CreditCardRegex { get; set; }
+        public string EmailAddressRegex { get; set; }
+        public string UrlRegex { get; set; }
+
+        public override bool Equals(object obj)
+            => obj is ValidationCheckConstraintOptions other && Equals(other);
+
+        public bool Equals(ValidationCheckConstraintOptions other)
+            => other != null
+                && PhoneRegex == other.PhoneRegex
+                && CreditCardRegex == other.CreditCardRegex
+                && EmailAddressRegex == other.EmailAddressRegex
+                && UrlRegex == other.UrlRegex;
+
+        public override int GetHashCode()
+            => HashCode.Combine(PhoneRegex, CreditCardRegex, EmailAddressRegex, UrlRegex);
+    }
+}

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptionsBuilder.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptionsBuilder.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace EFCore.CheckConstraints.Internal
+{
+    public class ValidationCheckConstraintOptionsBuilder
+    {
+        private readonly ValidationCheckConstraintOptions _options = new ValidationCheckConstraintOptions();
+
+        public virtual ValidationCheckConstraintOptions Options => _options;
+
+        public virtual ValidationCheckConstraintOptionsBuilder UsePhoneRegex([CanBeNull] string phoneRegex)
+        {
+            _options.PhoneRegex = phoneRegex;
+            return this;
+        }
+
+        public virtual ValidationCheckConstraintOptionsBuilder UseCreditCardRegex([CanBeNull] string creditCardRegex)
+        {
+            _options.CreditCardRegex = creditCardRegex;
+            return this;
+        }
+
+        public virtual ValidationCheckConstraintOptionsBuilder UseEmailRegex([CanBeNull] string emailRegex)
+        {
+            _options.EmailAddressRegex = emailRegex;
+            return this;
+        }
+
+        public virtual ValidationCheckConstraintOptionsBuilder UseUrlRegex([CanBeNull] string urlRegex)
+        {
+            _options.UrlRegex = urlRegex;
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
Closes #5

This hardcodes support for specific providers. Once dotnet/efcore#15409 is done, we can modify this to generate expression trees instead, and have the provide do the proper translation.

Notes:

* Both SQL Server and Sqlite need special setup in order to have regex, the docs will point that out.
* The validation in the .NET validation attributes is sometimes really odd - I don't consider them very good. I currently implemented to reproduce the same behavior in regex, but how important is exact compatibility with the .NET attribute, maybe we should just do better? Note that users can configure the regexes they want in any case.
* [Compare]: is there any real use-case for this in a database? Sounds like it should be a computed column instead, no?
* [DataType]: some of the values duplicate dedicated attributes (phone number, credit card, but not postal code (?)), others seem to be more about actual types (DateTime, Duration) which seem more appropriate for database types. So the value of this seems somewhat limited ()
* [CreditCard]: we do not do checksum
* Do a special [LikeValidation] attribute? Becomes pretty close to just having a [CheckConstraint] in EFCore.Abstractions (which we should probably do)

/cc @bricelam @ajcvickers @AndriySvyryd @smitpatel @maumar