### PR TITLE
Option added to disable regular expression constraints.

### DIFF
--- a/EFCore.CheckConstraints.Test/OptionsBuilderTest.cs
+++ b/EFCore.CheckConstraints.Test/OptionsBuilderTest.cs
@@ -1,0 +1,166 @@
+﻿using System.Linq;
+using EFCore.CheckConstraints.Internal;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace EFCore.CheckConstraints.Test
+{
+    public class OptionsBuilderTest
+    {
+        [Fact]
+        public void DiscriminatorCheckConstraintOptionsTest()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+
+            optionsBuilder.UseDiscriminatorCheckConstraints();
+
+            var extensions = optionsBuilder.Options.Extensions.ToArray();
+
+            Assert.Single(extensions);
+
+            var options = extensions[0] as CheckConstraintsOptionsExtension;
+
+            Assert.NotNull(options);
+            Assert.True(options.AreDiscriminatorCheckConstraintsEnabled);
+            Assert.False(options.AreEnumCheckConstraintsEnabled);
+            Assert.False(options.AreValidationCheckConstraintsEnabled);
+            Assert.Equal("using check constraints (discriminators)", options.Info.LogFragment);
+            Assert.Null(options.ValidationCheckConstraintOptions);
+        }
+
+        [Fact]
+        public void EnumCheckConstraintOptionsTest()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+
+            optionsBuilder.UseEnumCheckConstraints();
+
+            var extensions = optionsBuilder.Options.Extensions.ToArray();
+
+            Assert.Single(extensions);
+
+            var options = extensions[0] as CheckConstraintsOptionsExtension;
+
+            Assert.NotNull(options);
+            Assert.False(options.AreDiscriminatorCheckConstraintsEnabled);
+            Assert.True(options.AreEnumCheckConstraintsEnabled);
+            Assert.False(options.AreValidationCheckConstraintsEnabled);
+            Assert.Equal("using check constraints (enums)", options.Info.LogFragment);
+            Assert.Null(options.ValidationCheckConstraintOptions);
+        }
+
+        [Fact]
+        public void ValidationCheckConstraintOptionsTest()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+
+            optionsBuilder.UseValidationCheckConstraints();
+
+            var extensions = optionsBuilder.Options.Extensions.ToArray();
+
+            Assert.Single(extensions);
+
+            var options = extensions[0] as CheckConstraintsOptionsExtension;
+
+            Assert.NotNull(options);
+            Assert.False(options.AreDiscriminatorCheckConstraintsEnabled);
+            Assert.False(options.AreEnumCheckConstraintsEnabled);
+            Assert.True(options.AreValidationCheckConstraintsEnabled);
+            Assert.Equal("using check constraints (validation)", options.Info.LogFragment);
+            Assert.NotNull(options.ValidationCheckConstraintOptions);
+
+            var validationOptions = options.ValidationCheckConstraintOptions;
+
+            Assert.Null(validationOptions.CreditCardRegex);
+            Assert.Null(validationOptions.EmailAddressRegex);
+            Assert.Null(validationOptions.PhoneRegex);
+            Assert.Null(validationOptions.UrlRegex);
+            Assert.True(validationOptions.UseRegex);
+        }
+
+        [Fact]
+        public void ValidationCheckConstraintOptionsNoRegexTest()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+
+            optionsBuilder.UseValidationCheckConstraints(options => options.UseRegex(false));
+
+            var extensions = optionsBuilder.Options.Extensions.ToArray();
+
+            Assert.Single(extensions);
+
+            var options = extensions[0] as CheckConstraintsOptionsExtension;
+
+            Assert.NotNull(options);
+            Assert.False(options.AreDiscriminatorCheckConstraintsEnabled);
+            Assert.False(options.AreEnumCheckConstraintsEnabled);
+            Assert.True(options.AreValidationCheckConstraintsEnabled);
+            Assert.Equal("using check constraints (validation)", options.Info.LogFragment);
+            Assert.NotNull(options.ValidationCheckConstraintOptions);
+
+            var validationOptions = options.ValidationCheckConstraintOptions;
+
+            Assert.Null(validationOptions.CreditCardRegex);
+            Assert.Null(validationOptions.EmailAddressRegex);
+            Assert.Null(validationOptions.PhoneRegex);
+            Assert.Null(validationOptions.UrlRegex);
+            Assert.False(validationOptions.UseRegex);
+        }
+
+        [Fact]
+        public void AllCheckConstraintOptionsTest()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+
+            optionsBuilder.UseAllCheckConstraints();
+
+            var extensions = optionsBuilder.Options.Extensions.ToArray();
+
+            Assert.Single(extensions);
+
+            var options = extensions[0] as CheckConstraintsOptionsExtension;
+
+            Assert.NotNull(options);
+            Assert.True(options.AreDiscriminatorCheckConstraintsEnabled);
+            Assert.True(options.AreEnumCheckConstraintsEnabled);
+            Assert.True(options.AreValidationCheckConstraintsEnabled);
+            Assert.NotNull(options.ValidationCheckConstraintOptions);
+
+            var validationOptions = options.ValidationCheckConstraintOptions;
+
+            Assert.Null(validationOptions.CreditCardRegex);
+            Assert.Null(validationOptions.EmailAddressRegex);
+            Assert.Null(validationOptions.PhoneRegex);
+            Assert.Null(validationOptions.UrlRegex);
+            Assert.True(validationOptions.UseRegex);
+        }
+
+        [Fact]
+        public void AllCheckConstraintOptionsNoRegexTest()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+
+            optionsBuilder.UseAllCheckConstraints(options => options.UseRegex(false));
+
+            var extensions = optionsBuilder.Options.Extensions.ToArray();
+
+            Assert.Single(extensions);
+
+            var options = extensions[0] as CheckConstraintsOptionsExtension;
+
+            Assert.NotNull(options);
+            Assert.True(options.AreDiscriminatorCheckConstraintsEnabled);
+            Assert.True(options.AreEnumCheckConstraintsEnabled);
+            Assert.True(options.AreValidationCheckConstraintsEnabled);
+            Assert.NotNull(options.ValidationCheckConstraintOptions);
+
+            var validationOptions = options.ValidationCheckConstraintOptions;
+
+            Assert.Null(validationOptions.CreditCardRegex);
+            Assert.Null(validationOptions.EmailAddressRegex);
+            Assert.Null(validationOptions.PhoneRegex);
+            Assert.Null(validationOptions.UrlRegex);
+            Assert.False(validationOptions.UseRegex);
+        }
+    }
+}

--- a/EFCore.CheckConstraints.Test/ValidationCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/ValidationCheckConstraintTest.cs
@@ -46,6 +46,14 @@ namespace EFCore.CheckConstraints.Test
         }
 
         [Fact]
+        public void NoRegex()
+        {
+            var entityType = BuildEntityType<Blog>(useRegex: false);
+
+            Assert.DoesNotContain(entityType.GetCheckConstraints(), c => c.Name.StartsWith("dbo.RegexMatch("));
+        }
+
+        [Fact]
         public virtual void Phone()
         {
             var entityType = BuildEntityType<Blog>();
@@ -128,7 +136,7 @@ namespace EFCore.CheckConstraints.Test
         }
         // ReSharper restore UnusedMember.Local
 
-        private IModel BuildModel(Action<ModelBuilder> buildAction)
+        private IModel BuildModel(Action<ModelBuilder> buildAction, bool useRegex)
         {
             var serviceProvider = SqlServerTestHelpers.Instance.CreateContextServices();
 
@@ -136,7 +144,7 @@ namespace EFCore.CheckConstraints.Test
             ConventionSet.Remove(conventionSet.ModelFinalizedConventions, typeof(ValidatingConvention));
             conventionSet.ModelFinalizingConventions.Add(
                 new ValidationCheckConstraintConvention(
-                    new ValidationCheckConstraintOptions(),
+                    new ValidationCheckConstraintOptions() { UseRegex = useRegex },
                     serviceProvider.GetRequiredService<ISqlGenerationHelper>(),
                     serviceProvider.GetRequiredService<IRelationalTypeMappingSource>(),
                     serviceProvider.GetRequiredService<IDatabaseProvider>()));
@@ -146,12 +154,13 @@ namespace EFCore.CheckConstraints.Test
             return builder.FinalizeModel();
         }
 
-        private IEntityType BuildEntityType<TEntity>(Action<EntityTypeBuilder<TEntity>> buildAction = null)
+        private IEntityType BuildEntityType<TEntity>(Action<EntityTypeBuilder<TEntity>> buildAction = null, bool useRegex = true)
             where TEntity : class
         {
             return BuildModel(buildAction is null
                 ? b => b.Entity<TEntity>()
-                : b => buildAction(b.Entity<TEntity>())).GetEntityTypes().Single();
+                : b => buildAction(b.Entity<TEntity>()),
+                useRegex).GetEntityTypes().Single();
         }
 
         #endregion

--- a/EFCore.CheckConstraints.sln
+++ b/EFCore.CheckConstraints.sln
@@ -6,8 +6,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore.CheckConstraints.Tes
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F6BE1E4F-B395-456A-9856-0C9AE4F626C0}"
 ProjectSection(SolutionItems) = preProject
-	Directory.Build.props = Directory.Build.props
+	.editorconfig = .editorconfig
 	.github\workflows\build.yml = .github\workflows\build.yml
+	Directory.Build.props = Directory.Build.props
 	Directory.Packages.props = Directory.Packages.props
 EndProjectSection
 EndProject

--- a/EFCore.CheckConstraints/CheckConstraintsExtensions.cs
+++ b/EFCore.CheckConstraints/CheckConstraintsExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using EFCore.CheckConstraints;
 using EFCore.CheckConstraints.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;

--- a/EFCore.CheckConstraints/CheckConstraintsExtensions.cs
+++ b/EFCore.CheckConstraints/CheckConstraintsExtensions.cs
@@ -6,8 +6,23 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
+    /// <summary>
+    ///     Extension methods for adding column check constraints to database tables.
+    /// </summary>
     public static class CheckConstraintsExtensions
     {
+        /// <summary>
+        ///     Adds or updates a <see cref="CheckConstraintsOptionsExtension"/>
+        ///     object with enum check constraints enabled
+        ///     to the current <see cref="DbContextOptionsBuilder"/> object.
+        /// </summary>
+        /// <param name="optionsBuilder">
+        ///     <see cref="DbContextOptionsBuilder"/> object having <see cref="CheckConstraintsOptionsExtension"/>
+        ///     added or updated with enum check constraints enabled.
+        /// </param>
+        /// <returns>
+        ///     The current <see cref="DbContextOptionsBuilder"/> object.
+        /// </returns>
         public static DbContextOptionsBuilder UseEnumCheckConstraints(
             [NotNull] this DbContextOptionsBuilder optionsBuilder)
         {
@@ -21,6 +36,18 @@ namespace Microsoft.EntityFrameworkCore
             return optionsBuilder;
         }
 
+        /// <summary>
+        ///     Adds or updates a <see cref="CheckConstraintsOptionsExtension"/>
+        ///     object with discriminator check constraints enabled
+        ///     to the current <see cref="DbContextOptionsBuilder"/> object.
+        /// </summary>
+        /// <param name="optionsBuilder">
+        ///     <see cref="DbContextOptionsBuilder"/> object having <see cref="CheckConstraintsOptionsExtension"/>
+        ///     added or updated with discriminator check constraints enabled.
+        /// </param>
+        /// <returns>
+        ///     The current <see cref="DbContextOptionsBuilder"/> object.
+        /// </returns>
         public static DbContextOptionsBuilder UseDiscriminatorCheckConstraints(
             [NotNull] this DbContextOptionsBuilder optionsBuilder)
         {
@@ -34,6 +61,21 @@ namespace Microsoft.EntityFrameworkCore
             return optionsBuilder;
         }
 
+        /// <summary>
+        ///     Adds or updates a <see cref="CheckConstraintsOptionsExtension"/>
+        ///     object with validation check constraints enabled
+        ///     to the current <see cref="DbContextOptionsBuilder"/> object.
+        /// </summary>
+        /// <param name="optionsBuilder">
+        ///     <see cref="DbContextOptionsBuilder"/> object having <see cref="CheckConstraintsOptionsExtension"/>
+        ///     added or updated with validation check constraints enabled.
+        /// </param>
+        /// <param name="validationCheckConstraintsOptionsAction">
+        ///     Configures validation check constraint creation.
+        /// </param>
+        /// <returns>
+        ///     The current <see cref="DbContextOptionsBuilder"/> object.
+        /// </returns>
         public static DbContextOptionsBuilder UseValidationCheckConstraints(
             [NotNull] this DbContextOptionsBuilder optionsBuilder,
             [CanBeNull] Action<ValidationCheckConstraintOptionsBuilder> validationCheckConstraintsOptionsAction = null)
@@ -51,6 +93,21 @@ namespace Microsoft.EntityFrameworkCore
             return optionsBuilder;
         }
 
+        /// <summary>
+        ///     Adds or updates a <see cref="CheckConstraintsOptionsExtension"/>
+        ///     object with all kinds of check constraints enabled
+        ///     to the current <see cref="DbContextOptionsBuilder"/> object.
+        /// </summary>
+        /// <param name="optionsBuilder">
+        ///     <see cref="DbContextOptionsBuilder"/> object having <see cref="CheckConstraintsOptionsExtension"/>
+        ///     added or updated with all kinds of check constraints enabled.
+        /// </param>
+        /// <param name="validationCheckConstraintsOptionsAction">
+        ///     Configures validation check constraint creation.
+        /// </param>
+        /// <returns>
+        ///     The current <see cref="DbContextOptionsBuilder"/> object.
+        /// </returns>
         public static DbContextOptionsBuilder UseAllCheckConstraints(
             [NotNull] this DbContextOptionsBuilder optionsBuilder,
             [CanBeNull] Action<ValidationCheckConstraintOptionsBuilder> validationCheckConstraintsOptionsAction = null)
@@ -59,18 +116,92 @@ namespace Microsoft.EntityFrameworkCore
                 .UseDiscriminatorCheckConstraints()
                 .UseValidationCheckConstraints(validationCheckConstraintsOptionsAction);
 
+
+
+        /// <summary>
+        ///     Adds or updates a <see cref="CheckConstraintsOptionsExtension"/>
+        ///     object with enum check constraints enabled
+        ///     to the current <see cref="DbContextOptionsBuilder{TContext}"/> object.
+        /// </summary>
+        /// <typeparam name="TContext">
+        ///     Entity Framework Core database context type.
+        /// </typeparam>
+        /// <param name="optionsBuilder">
+        ///     <see cref="DbContextOptionsBuilder{TContext}"/> object having <see cref="CheckConstraintsOptionsExtension"/>
+        ///     added or updated with enum check constraints enabled.
+        /// </param>
+        /// <returns>
+        ///     The current <see cref="DbContextOptionsBuilder{TContext}"/> object.
+        /// </returns>
         public static DbContextOptionsBuilder<TContext> UseEnumCheckConstraints<TContext>([NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder)
             where TContext : DbContext
             => (DbContextOptionsBuilder<TContext>)UseEnumCheckConstraints((DbContextOptionsBuilder)optionsBuilder);
 
+        /// <summary>
+        ///     Adds or updates a <see cref="CheckConstraintsOptionsExtension"/>
+        ///     object with discriminator check constraints enabled
+        ///     to the current <see cref="DbContextOptionsBuilder{TContext}"/> object.
+        /// </summary>
+        /// <typeparam name="TContext">
+        ///     Entity Framework Core database context type.
+        /// </typeparam>
+        /// <param name="optionsBuilder">
+        ///     <see cref="DbContextOptionsBuilder{TContext}"/> object having <see cref="CheckConstraintsOptionsExtension"/>
+        ///     added or updated with discriminator check constraints enabled.
+        /// </param>
+        /// <returns>
+        ///     The current <see cref="DbContextOptionsBuilder{TContext}"/> object.
+        /// </returns>
         public static DbContextOptionsBuilder<TContext> UseDiscriminatorCheckConstraints<TContext>([NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder)
             where TContext : DbContext
             => (DbContextOptionsBuilder<TContext>)UseDiscriminatorCheckConstraints((DbContextOptionsBuilder)optionsBuilder);
 
+        /// <summary>
+        ///     Adds or updates a <see cref="CheckConstraintsOptionsExtension"/>
+        ///     object with validation check constraints enabled
+        ///     to the current <see cref="DbContextOptionsBuilder{TContext}"/> object.
+        /// </summary>
+        /// <typeparam name="TContext">
+        ///     Entity Framework Core database context type.
+        /// </typeparam>
+        /// <param name="optionsBuilder">
+        ///     <see cref="DbContextOptionsBuilder{TContext}"/> object having <see cref="CheckConstraintsOptionsExtension"/>
+        ///     added or updated with validation check constraints enabled.
+        /// </param>
+        /// <param name="validationCheckConstraintsOptionsAction">
+        ///     Configures validation check constraint creation.
+        /// </param>
+        /// <returns>
+        ///     The current <see cref="DbContextOptionsBuilder{TContext}"/> object.
+        /// </returns>
         public static DbContextOptionsBuilder<TContext> UseValidationCheckConstraints<TContext>(
             [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
             [CanBeNull] Action<ValidationCheckConstraintOptionsBuilder> validationCheckConstraintsOptionsAction = null)
             where TContext : DbContext
             => (DbContextOptionsBuilder<TContext>)UseValidationCheckConstraints((DbContextOptionsBuilder)optionsBuilder, validationCheckConstraintsOptionsAction);
+
+        /// <summary>
+        ///     Adds or updates a <see cref="CheckConstraintsOptionsExtension"/>
+        ///     object with all check constraints enabled
+        ///     to the current <see cref="DbContextOptionsBuilder{TContext}"/> object.
+        /// </summary>
+        /// <typeparam name="TContext">
+        ///     Entity Framework Core database context type.
+        /// </typeparam>
+        /// <param name="optionsBuilder">
+        ///     <see cref="DbContextOptionsBuilder{TContext}"/> object having <see cref="CheckConstraintsOptionsExtension"/>
+        ///     added or updated with all check constraints enabled.
+        /// </param>
+        /// <param name="validationCheckConstraintsOptionsAction">
+        ///     Configures validation check constraint creation.
+        /// </param>
+        /// <returns>
+        ///     The current <see cref="DbContextOptionsBuilder{TContext}"/> object.
+        /// </returns>
+        public static DbContextOptionsBuilder<TContext> UseAllCheckConstraints<TContext>(
+            [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
+            [CanBeNull] Action<ValidationCheckConstraintOptionsBuilder> validationCheckConstraintsOptionsAction = null)
+            where TContext : DbContext
+            => (DbContextOptionsBuilder<TContext>)UseAllCheckConstraints((DbContextOptionsBuilder)optionsBuilder, validationCheckConstraintsOptionsAction);
     }
 }

--- a/EFCore.CheckConstraints/CheckConstraintsExtensions.cs
+++ b/EFCore.CheckConstraints/CheckConstraintsExtensions.cs
@@ -1,8 +1,7 @@
 using System;
-using System.Globalization;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using JetBrains.Annotations;
 using EFCore.CheckConstraints.Internal;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
@@ -53,11 +52,12 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         public static DbContextOptionsBuilder UseAllCheckConstraints(
-            [NotNull] this DbContextOptionsBuilder optionsBuilder)
+            [NotNull] this DbContextOptionsBuilder optionsBuilder,
+            [CanBeNull] Action<ValidationCheckConstraintOptionsBuilder> validationCheckConstraintsOptionsAction = null)
             => optionsBuilder
                 .UseEnumCheckConstraints()
                 .UseDiscriminatorCheckConstraints()
-                .UseValidationCheckConstraints();
+                .UseValidationCheckConstraints(validationCheckConstraintsOptionsAction);
 
         public static DbContextOptionsBuilder<TContext> UseEnumCheckConstraints<TContext>([NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder)
             where TContext : DbContext

--- a/EFCore.CheckConstraints/CheckConstraintsServiceCollectionExtensions.cs
+++ b/EFCore.CheckConstraints/CheckConstraintsServiceCollectionExtensions.cs
@@ -1,8 +1,8 @@
+using EFCore.CheckConstraints.Internal;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
-using EFCore.CheckConstraints.Internal;
-using JetBrains.Annotations;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection

--- a/EFCore.CheckConstraints/EFCore.CheckConstraints.csproj
+++ b/EFCore.CheckConstraints/EFCore.CheckConstraints.csproj
@@ -19,6 +19,10 @@
     <RepositoryUrl>git://github.com/efcore/EFCore.CheckConstraints</RepositoryUrl>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
+    <DocumentationFile>obj\EFCore.CheckConstraints.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />

--- a/EFCore.CheckConstraints/EFCore.CheckConstraints.csproj
+++ b/EFCore.CheckConstraints/EFCore.CheckConstraints.csproj
@@ -17,10 +17,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/efcore/EFCore.CheckConstraints</RepositoryUrl>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
-    <DocumentationFile>obj\EFCore.CheckConstraints.xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EFCore.CheckConstraints/Internal/.editorconfig
+++ b/EFCore.CheckConstraints/Internal/.editorconfig
@@ -1,0 +1,5 @@
+[*.cs]
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none
+

--- a/EFCore.CheckConstraints/Internal/CheckConstraintsConventionSetPlugin.cs
+++ b/EFCore.CheckConstraints/Internal/CheckConstraintsConventionSetPlugin.cs
@@ -6,10 +6,6 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace EFCore.CheckConstraints.Internal
 {
-    /// <summary>
-    ///     Customizes the <see cref="ConventionSet"/> being used by adding
-    ///     database table column check constraints according to data annotations.
-    /// </summary>
     public class CheckConstraintsConventionSetPlugin : IConventionSetPlugin
     {
         private readonly IDbContextOptions _options;
@@ -17,21 +13,6 @@ namespace EFCore.CheckConstraints.Internal
         private readonly IRelationalTypeMappingSource _relationalTypeMappingSource;
         private readonly IDatabaseProvider _databaseProvider;
 
-        /// <summary>
-        ///     Creates a new <see cref="CheckConstraintsConventionSetPlugin"/> object.
-        /// </summary>
-        /// <param name="options">
-        ///     Collection of database context option extensions.
-        /// </param>
-        /// <param name="sqlGenerationHelper">
-        ///     Service to help with generation of SQL commands.
-        /// </param>
-        /// <param name="relationalTypeMappingSource">
-        ///     Relational type mapping interface for EF Core.
-        /// </param>
-        /// <param name="databaseProvider">
-        ///     The current database provider.
-        /// </param>
         public CheckConstraintsConventionSetPlugin(
             [NotNull] IDbContextOptions options,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
@@ -44,16 +25,6 @@ namespace EFCore.CheckConstraints.Internal
             _databaseProvider = databaseProvider;
         }
 
-        /// <summary>
-        ///     Modifies the given convention set by adding table
-        ///     column check constraint conventions.
-        /// </summary>
-        /// <param name="conventionSet">
-        ///     The <see cref="ConventionSet"/> object to modify.
-        /// </param>
-        /// <returns>
-        ///     The modified <see cref="ConventionSet"/> object.
-        /// </returns>
         public ConventionSet ModifyConventions(ConventionSet conventionSet)
         {
             var extension = _options.FindExtension<CheckConstraintsOptionsExtension>();

--- a/EFCore.CheckConstraints/Internal/CheckConstraintsConventionSetPlugin.cs
+++ b/EFCore.CheckConstraints/Internal/CheckConstraintsConventionSetPlugin.cs
@@ -1,11 +1,15 @@
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
-using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace EFCore.CheckConstraints.Internal
 {
+    /// <summary>
+    ///     Customizes the <see cref="ConventionSet"/> being used by adding
+    ///     database table column check constraints according to data annotations.
+    /// </summary>
     public class CheckConstraintsConventionSetPlugin : IConventionSetPlugin
     {
         private readonly IDbContextOptions _options;
@@ -13,6 +17,21 @@ namespace EFCore.CheckConstraints.Internal
         private readonly IRelationalTypeMappingSource _relationalTypeMappingSource;
         private readonly IDatabaseProvider _databaseProvider;
 
+        /// <summary>
+        ///     Creates a new <see cref="CheckConstraintsConventionSetPlugin"/> object.
+        /// </summary>
+        /// <param name="options">
+        ///     Collection of database context option extensions.
+        /// </param>
+        /// <param name="sqlGenerationHelper">
+        ///     Service to help with generation of SQL commands.
+        /// </param>
+        /// <param name="relationalTypeMappingSource">
+        ///     Relational type mapping interface for EF Core.
+        /// </param>
+        /// <param name="databaseProvider">
+        ///     The current database provider.
+        /// </param>
         public CheckConstraintsConventionSetPlugin(
             [NotNull] IDbContextOptions options,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
@@ -25,6 +44,16 @@ namespace EFCore.CheckConstraints.Internal
             _databaseProvider = databaseProvider;
         }
 
+        /// <summary>
+        ///     Modifies the given convention set by adding table
+        ///     column check constraint conventions.
+        /// </summary>
+        /// <param name="conventionSet">
+        ///     The <see cref="ConventionSet"/> object to modify.
+        /// </param>
+        /// <returns>
+        ///     The modified <see cref="ConventionSet"/> object.
+        /// </returns>
         public ConventionSet ModifyConventions(ConventionSet conventionSet)
         {
             var extension = _options.FindExtension<CheckConstraintsOptionsExtension>();

--- a/EFCore.CheckConstraints/Internal/CheckConstraintsOptionsExtension.cs
+++ b/EFCore.CheckConstraints/Internal/CheckConstraintsOptionsExtension.cs
@@ -8,11 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace EFCore.CheckConstraints.Internal
 {
-    /// <summary>
-    ///     Entity Framework Core database context options extension
-    ///     configuring how table column check constraints will
-    ///     be created from data annotations.
-    /// </summary>
     public class CheckConstraintsOptionsExtension : IDbContextOptionsExtension
     {
         private DbContextOptionsExtensionInfo _info;
@@ -20,18 +15,8 @@ namespace EFCore.CheckConstraints.Internal
         private bool _discriminatorCheckConstraintsEnabled;
         private ValidationCheckConstraintOptions _validationCheckConstraintsOptions;
 
-        /// <summary>
-        ///     Creates a new <see cref="CheckConstraintsOptionsExtension"/> object.
-        /// </summary>
         public CheckConstraintsOptionsExtension() {}
 
-        /// <summary>
-        ///     Creates a new <see cref="CheckConstraintsOptionsExtension"/> object
-        ///     from a given <see cref="CheckConstraintsOptionsExtension"/> object.
-        /// </summary>
-        /// <param name="copyFrom">
-        ///     <see cref="CheckConstraintsOptionsExtension"/> object to copy.
-        /// </param>
         protected CheckConstraintsOptionsExtension([NotNull] CheckConstraintsOptionsExtension copyFrom)
         {
             _enumCheckConstraintsEnabled = copyFrom._enumCheckConstraintsEnabled;
@@ -41,53 +26,18 @@ namespace EFCore.CheckConstraints.Internal
                 : new ValidationCheckConstraintOptions(copyFrom._validationCheckConstraintsOptions);
         }
 
-        /// <summary>
-        ///     Information/metadata about the Entity Framework Core
-        ///     database context options extension, used for logging/debugging.
-        /// </summary>
         public virtual DbContextOptionsExtensionInfo Info => _info ??= new ExtensionInfo(this);
 
-        /// <summary>
-        ///     Creates a cloned copy from the current
-        ///     <see cref="CheckConstraintsOptionsExtension"/> object.
-        /// </summary>
-        /// <returns>
-        ///     A new <see cref="CheckConstraintsOptionsExtension"/> object, cloned
-        ///     from the current <see cref="CheckConstraintsOptionsExtension"/> object.
-        /// </returns>
         protected virtual CheckConstraintsOptionsExtension Clone() => new CheckConstraintsOptionsExtension(this);
 
-        /// <summary>
-        ///     <c>true</c>, if enum check constraints are enabled; <c>false</c> otherwise.
-        /// </summary>
         public virtual bool AreEnumCheckConstraintsEnabled => _enumCheckConstraintsEnabled;
 
-        /// <summary>
-        ///     <c>true</c>, if discriminator check constraints are enabled; <c>false</c> otherwise.
-        /// </summary>
         public virtual bool AreDiscriminatorCheckConstraintsEnabled => _discriminatorCheckConstraintsEnabled;
 
-        /// <summary>
-        ///     <c>true</c>, if validation check constraints are enabled; <c>false</c> otherwise.
-        /// </summary>
         public virtual bool AreValidationCheckConstraintsEnabled => _validationCheckConstraintsOptions != null;
 
-        /// <summary>
-        ///     The currently configured <see cref="ValidationCheckConstraintOptions"/>. May be <c>null</c>.
-        /// </summary>
         public virtual ValidationCheckConstraintOptions ValidationCheckConstraintOptions => _validationCheckConstraintsOptions;
 
-        /// <summary>
-        ///     Creates a new <see cref="CheckConstraintsOptionsExtension"/> object
-        ///     having enum check constraints enabled or disabled.
-        /// </summary>
-        /// <param name="enumCheckConstraintsEnabled">
-        ///     <c>true</c>, if enum check constraints are enabled; <c>false</c> otherwise.
-        /// </param>
-        /// <returns>
-        ///     New <see cref="CheckConstraintsOptionsExtension"/> object,
-        ///     having enum check constraints enabled or disabled.
-        /// </returns>
         public virtual CheckConstraintsOptionsExtension WithEnumCheckConstraintsEnabled(
             bool enumCheckConstraintsEnabled)
         {
@@ -96,17 +46,6 @@ namespace EFCore.CheckConstraints.Internal
             return clone;
         }
 
-        /// <summary>
-        ///     Creates a new <see cref="CheckConstraintsOptionsExtension"/> object
-        ///     having discriminator check constraints enabled or disabled.
-        /// </summary>
-        /// <param name="discriminatorCheckConstraintsEnabled">
-        ///     <c>true</c>, if discriminator check constraints are enabled; <c>false</c> otherwise.
-        /// </param>
-        /// <returns>
-        ///     New <see cref="CheckConstraintsOptionsExtension"/> object,
-        ///     having discriminator check constraints enabled or disabled.
-        /// </returns>
         public virtual CheckConstraintsOptionsExtension WithDiscriminatorCheckConstraintsEnabled(
             bool discriminatorCheckConstraintsEnabled)
         {
@@ -115,19 +54,6 @@ namespace EFCore.CheckConstraints.Internal
             return clone;
         }
 
-        /// <summary>
-        ///     Creates a new <see cref="CheckConstraintsOptionsExtension"/> object
-        ///     having validation check constraints configured.
-        /// </summary>
-        /// <param name="validationCheckConstraintsOptions">
-        ///     <see cref="ValidationCheckConstraintOptions"/> to be applied to the new
-        ///     <see cref="CheckConstraintsOptionsExtension"/> object. Set to <c>null</c>
-        ///     to disable validation check constraints.
-        /// </param>
-        /// <returns>
-        ///     New <see cref="CheckConstraintsOptionsExtension"/> object,
-        ///     having validation check constraints configured.
-        /// </returns>
         public virtual CheckConstraintsOptionsExtension WithValidationCheckConstraintsOptions(
             ValidationCheckConstraintOptions validationCheckConstraintsOptions)
         {
@@ -136,28 +62,11 @@ namespace EFCore.CheckConstraints.Internal
             return clone;
         }
 
-        /// <summary>
-        ///     Checks if all options are valid.
-        /// </summary>
-        /// <param name="options">
-        ///     Collection of Entity Framework Core database context option extensions.
-        /// </param>
         public void Validate(IDbContextOptions options) {}
 
-        /// <summary>
-        ///     Adds the table column check constraint service to the list of
-        ///     Entity Framework Core database services.
-        /// </summary>
-        /// <param name="services">
-        ///     The collection to add services to.
-        /// </param>
         public void ApplyServices(IServiceCollection services)
             => services.AddEntityFrameworkCheckConstraints();
 
-        /// <summary>
-        ///     Information/metadata about the Entity Framework Core
-        ///     database context options extension, used for logging/debugging.
-        /// </summary>
         internal sealed class ExtensionInfo : DbContextOptionsExtensionInfo
         {
             private string _logFragment;

--- a/EFCore.CheckConstraints/Internal/CheckConstraintsOptionsExtension.cs
+++ b/EFCore.CheckConstraints/Internal/CheckConstraintsOptionsExtension.cs
@@ -2,12 +2,17 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
-using JetBrains.Annotations;
 
 namespace EFCore.CheckConstraints.Internal
 {
+    /// <summary>
+    ///     Entity Framework Core database context options extension
+    ///     configuring how table column check constraints will
+    ///     be created from data annotations.
+    /// </summary>
     public class CheckConstraintsOptionsExtension : IDbContextOptionsExtension
     {
         private DbContextOptionsExtensionInfo _info;
@@ -15,8 +20,20 @@ namespace EFCore.CheckConstraints.Internal
         private bool _discriminatorCheckConstraintsEnabled;
         private ValidationCheckConstraintOptions _validationCheckConstraintsOptions;
 
+
+
+        /// <summary>
+        ///     Creates a new <see cref="CheckConstraintsOptionsExtension"/> object.
+        /// </summary>
         public CheckConstraintsOptionsExtension() {}
 
+        /// <summary>
+        ///     Creates a new <see cref="CheckConstraintsOptionsExtension"/> object
+        ///     from a given <see cref="CheckConstraintsOptionsExtension"/> object.
+        /// </summary>
+        /// <param name="copyFrom">
+        ///     <see cref="CheckConstraintsOptionsExtension"/> object to copy.
+        /// </param>
         protected CheckConstraintsOptionsExtension([NotNull] CheckConstraintsOptionsExtension copyFrom)
         {
             _enumCheckConstraintsEnabled = copyFrom._enumCheckConstraintsEnabled;
@@ -26,15 +43,59 @@ namespace EFCore.CheckConstraints.Internal
                 : new ValidationCheckConstraintOptions(copyFrom._validationCheckConstraintsOptions);
         }
 
+
+
+        /// <summary>
+        ///     Information/metadata about the Entity Framework Core
+        ///     database context options extension, used for logging/debugging.
+        /// </summary>
         public virtual DbContextOptionsExtensionInfo Info => _info ??= new ExtensionInfo(this);
 
+        /// <summary>
+        ///     Creates a cloned copy from the current
+        ///     <see cref="CheckConstraintsOptionsExtension"/> object.
+        /// </summary>
+        /// <returns>
+        ///     A new <see cref="CheckConstraintsOptionsExtension"/> object, cloned
+        ///     from the current <see cref="CheckConstraintsOptionsExtension"/> object.
+        /// </returns>
         protected virtual CheckConstraintsOptionsExtension Clone() => new CheckConstraintsOptionsExtension(this);
 
+
+
+        /// <summary>
+        ///     <c>true</c>, if enum check constraints are enabled; <c>false</c> otherwise.
+        /// </summary>
         public virtual bool AreEnumCheckConstraintsEnabled => _enumCheckConstraintsEnabled;
+
+        /// <summary>
+        ///     <c>true</c>, if discriminator check constraints are enabled; <c>false</c> otherwise.
+        /// </summary>
         public virtual bool AreDiscriminatorCheckConstraintsEnabled => _discriminatorCheckConstraintsEnabled;
+
+        /// <summary>
+        ///     <c>true</c>, if validation check constraints are enabled; <c>false</c> otherwise.
+        /// </summary>
         public virtual bool AreValidationCheckConstraintsEnabled => _validationCheckConstraintsOptions != null;
+
+        /// <summary>
+        ///     The currently configured <see cref="ValidationCheckConstraintOptions"/>. May be <c>null</c>.
+        /// </summary>
         public virtual ValidationCheckConstraintOptions ValidationCheckConstraintOptions => _validationCheckConstraintsOptions;
 
+
+
+        /// <summary>
+        ///     Creates a new <see cref="CheckConstraintsOptionsExtension"/> object
+        ///     having enum check constraints enabled or disabled.
+        /// </summary>
+        /// <param name="enumCheckConstraintsEnabled">
+        ///     <c>true</c>, if enum check constraints are enabled; <c>false</c> otherwise.
+        /// </param>
+        /// <returns>
+        ///     New <see cref="CheckConstraintsOptionsExtension"/> object,
+        ///     having enum check constraints enabled or disabled.
+        /// </returns>
         public virtual CheckConstraintsOptionsExtension WithEnumCheckConstraintsEnabled(
             bool enumCheckConstraintsEnabled)
         {
@@ -43,6 +104,17 @@ namespace EFCore.CheckConstraints.Internal
             return clone;
         }
 
+        /// <summary>
+        ///     Creates a new <see cref="CheckConstraintsOptionsExtension"/> object
+        ///     having discriminator check constraints enabled or disabled.
+        /// </summary>
+        /// <param name="discriminatorCheckConstraintsEnabled">
+        ///     <c>true</c>, if discriminator check constraints are enabled; <c>false</c> otherwise.
+        /// </param>
+        /// <returns>
+        ///     New <see cref="CheckConstraintsOptionsExtension"/> object,
+        ///     having discriminator check constraints enabled or disabled.
+        /// </returns>
         public virtual CheckConstraintsOptionsExtension WithDiscriminatorCheckConstraintsEnabled(
             bool discriminatorCheckConstraintsEnabled)
         {
@@ -51,6 +123,19 @@ namespace EFCore.CheckConstraints.Internal
             return clone;
         }
 
+        /// <summary>
+        ///     Creates a new <see cref="CheckConstraintsOptionsExtension"/> object
+        ///     having validation check constraints configured.
+        /// </summary>
+        /// <param name="validationCheckConstraintsOptions">
+        ///     <see cref="ValidationCheckConstraintOptions"/> to be applied to the new
+        ///     <see cref="CheckConstraintsOptionsExtension"/> object. Set to <c>null</c>
+        ///     to disable validation check constraints.
+        /// </param>
+        /// <returns>
+        ///     New <see cref="CheckConstraintsOptionsExtension"/> object,
+        ///     having validation check constraints configured.
+        /// </returns>
         public virtual CheckConstraintsOptionsExtension WithValidationCheckConstraintsOptions(
             ValidationCheckConstraintOptions validationCheckConstraintsOptions)
         {
@@ -59,11 +144,33 @@ namespace EFCore.CheckConstraints.Internal
             return clone;
         }
 
+
+
+        /// <summary>
+        ///     Checks if all options are valid.
+        /// </summary>
+        /// <param name="options">
+        ///     Collection of Entity Framework Core database context option extensions.
+        /// </param>
         public void Validate(IDbContextOptions options) {}
 
+
+        /// <summary>
+        ///     Adds the table column check constraint service to the list of
+        ///     Entity Framework Core database services.
+        /// </summary>
+        /// <param name="services">
+        ///     The collection to add services to.
+        /// </param>
         public void ApplyServices(IServiceCollection services)
             => services.AddEntityFrameworkCheckConstraints();
 
+
+
+        /// <summary>
+        ///     Information/metadata about the Entity Framework Core
+        ///     database context options extension, used for logging/debugging.
+        /// </summary>
         internal sealed class ExtensionInfo : DbContextOptionsExtensionInfo
         {
             private string _logFragment;

--- a/EFCore.CheckConstraints/Internal/CheckConstraintsOptionsExtension.cs
+++ b/EFCore.CheckConstraints/Internal/CheckConstraintsOptionsExtension.cs
@@ -20,8 +20,6 @@ namespace EFCore.CheckConstraints.Internal
         private bool _discriminatorCheckConstraintsEnabled;
         private ValidationCheckConstraintOptions _validationCheckConstraintsOptions;
 
-
-
         /// <summary>
         ///     Creates a new <see cref="CheckConstraintsOptionsExtension"/> object.
         /// </summary>
@@ -43,8 +41,6 @@ namespace EFCore.CheckConstraints.Internal
                 : new ValidationCheckConstraintOptions(copyFrom._validationCheckConstraintsOptions);
         }
 
-
-
         /// <summary>
         ///     Information/metadata about the Entity Framework Core
         ///     database context options extension, used for logging/debugging.
@@ -60,8 +56,6 @@ namespace EFCore.CheckConstraints.Internal
         ///     from the current <see cref="CheckConstraintsOptionsExtension"/> object.
         /// </returns>
         protected virtual CheckConstraintsOptionsExtension Clone() => new CheckConstraintsOptionsExtension(this);
-
-
 
         /// <summary>
         ///     <c>true</c>, if enum check constraints are enabled; <c>false</c> otherwise.
@@ -82,8 +76,6 @@ namespace EFCore.CheckConstraints.Internal
         ///     The currently configured <see cref="ValidationCheckConstraintOptions"/>. May be <c>null</c>.
         /// </summary>
         public virtual ValidationCheckConstraintOptions ValidationCheckConstraintOptions => _validationCheckConstraintsOptions;
-
-
 
         /// <summary>
         ///     Creates a new <see cref="CheckConstraintsOptionsExtension"/> object
@@ -144,8 +136,6 @@ namespace EFCore.CheckConstraints.Internal
             return clone;
         }
 
-
-
         /// <summary>
         ///     Checks if all options are valid.
         /// </summary>
@@ -153,7 +143,6 @@ namespace EFCore.CheckConstraints.Internal
         ///     Collection of Entity Framework Core database context option extensions.
         /// </param>
         public void Validate(IDbContextOptions options) {}
-
 
         /// <summary>
         ///     Adds the table column check constraint service to the list of
@@ -164,8 +153,6 @@ namespace EFCore.CheckConstraints.Internal
         /// </param>
         public void ApplyServices(IServiceCollection services)
             => services.AddEntityFrameworkCheckConstraints();
-
-
 
         /// <summary>
         ///     Information/metadata about the Entity Framework Core

--- a/EFCore.CheckConstraints/Internal/DiscriminatorCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/DiscriminatorCheckConstraintConvention.cs
@@ -1,8 +1,8 @@
 using System.Linq;
 using System.Text;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -16,6 +16,12 @@ namespace EFCore.CheckConstraints.Internal
     {
         private readonly ISqlGenerationHelper _sqlGenerationHelper;
 
+        /// <summary>
+        ///     Creates a new <see cref="DiscriminatorCheckConstraintConvention"/> object.
+        /// </summary>
+        /// <param name="sqlGenerationHelper">
+        ///     Service to help with generation of SQL commands.
+        /// </param>
         public DiscriminatorCheckConstraintConvention(ISqlGenerationHelper sqlGenerationHelper)
             => _sqlGenerationHelper = sqlGenerationHelper;
 

--- a/EFCore.CheckConstraints/Internal/DiscriminatorCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/DiscriminatorCheckConstraintConvention.cs
@@ -8,24 +8,13 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace EFCore.CheckConstraints.Internal
 {
-    /// <summary>
-    ///     A convention that creates check constraints ensuring that (complete) discriminator columns only have
-    ///     expected values.
-    /// </summary>
     public class DiscriminatorCheckConstraintConvention : IModelFinalizingConvention
     {
         private readonly ISqlGenerationHelper _sqlGenerationHelper;
 
-        /// <summary>
-        ///     Creates a new <see cref="DiscriminatorCheckConstraintConvention"/> object.
-        /// </summary>
-        /// <param name="sqlGenerationHelper">
-        ///     Service to help with generation of SQL commands.
-        /// </param>
         public DiscriminatorCheckConstraintConvention(ISqlGenerationHelper sqlGenerationHelper)
             => _sqlGenerationHelper = sqlGenerationHelper;
 
-        /// <inheritdoc />
         public virtual void ProcessModelFinalizing(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
         {
             var sql = new StringBuilder();

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -8,23 +8,13 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace EFCore.CheckConstraints.Internal
 {
-    /// <summary>
-    ///     A convention that creates check constraints for enum columns.
-    /// </summary>
     public class EnumCheckConstraintConvention : IModelFinalizingConvention
     {
         private readonly ISqlGenerationHelper _sqlGenerationHelper;
 
-        /// <summary>
-        ///     Creates a new <see cref="EnumCheckConstraintConvention"/> object.
-        /// </summary>
-        /// <param name="sqlGenerationHelper">
-        ///     Service to help with generation of SQL commands.
-        /// </param>
         public EnumCheckConstraintConvention(ISqlGenerationHelper sqlGenerationHelper)
             => _sqlGenerationHelper = sqlGenerationHelper;
 
-        /// <inheritdoc />
         public virtual void ProcessModelFinalizing(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
         {
             var sql = new StringBuilder();

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -1,11 +1,10 @@
 using System;
 using System.Text;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using Microsoft.EntityFrameworkCore.Storage;
-using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace EFCore.CheckConstraints.Internal
 {
@@ -16,6 +15,12 @@ namespace EFCore.CheckConstraints.Internal
     {
         private readonly ISqlGenerationHelper _sqlGenerationHelper;
 
+        /// <summary>
+        ///     Creates a new <see cref="EnumCheckConstraintConvention"/> object.
+        /// </summary>
+        /// <param name="sqlGenerationHelper">
+        ///     Service to help with generation of SQL commands.
+        /// </param>
         public EnumCheckConstraintConvention(ISqlGenerationHelper sqlGenerationHelper)
             => _sqlGenerationHelper = sqlGenerationHelper;
 

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
@@ -43,7 +43,7 @@ namespace EFCore.CheckConstraints.Internal
         private readonly IDatabaseProvider _databaseProvider;
         private readonly RelationalTypeMapping _intTypeMapping;
 
-        private readonly bool _supportsRegex;
+        private readonly bool _useRegex;
         private readonly string _phoneRegex, _creditCardRegex, _emailAddressRegex, _urlRegex;
 
 
@@ -72,7 +72,7 @@ namespace EFCore.CheckConstraints.Internal
             _databaseProvider = databaseProvider;
             _intTypeMapping = relationalTypeMappingSource.FindMapping(typeof(int));
 
-            _supportsRegex = options.UseRegex && SupportsRegex;
+            _useRegex = options.UseRegex && SupportsRegex;
             _phoneRegex = options.PhoneRegex ?? DefaultPhoneRegex;
             _creditCardRegex = options.CreditCardRegex ?? DefaultCreditCardRegex;
             _emailAddressRegex = options.EmailAddressRegex ?? DefaultEmailAddressRegex;
@@ -110,7 +110,7 @@ namespace EFCore.CheckConstraints.Internal
                     ProcessMinLength(property, memberInfo, tableName, columnName, sql);
                     ProcessStringLengthMinimumLength(property, memberInfo, tableName, columnName, sql);
 
-                    if (_supportsRegex)
+                    if (_useRegex)
                     {
                         ProcessPhoneNumber(property, memberInfo, tableName, columnName, sql);
                         ProcessCreditCard(property, memberInfo, tableName, columnName, sql);
@@ -205,6 +205,26 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
+        /// <summary>
+        ///     Creates SQL check constraint clause for an entity property's
+        ///     <see cref="StringLengthAttribute.MinimumLength"/> data
+        ///     annotation attribute property.
+        /// </summary>
+        /// <param name="property">
+        ///     Property to be examined.
+        /// </param>
+        /// <param name="memberInfo">
+        ///     <see cref="MemberInfo"/> of property to be examined.
+        /// </param>
+        /// <param name="tableName">
+        ///     Database table name.
+        /// </param>
+        /// <param name="columnName">
+        ///     Database table column name.
+        /// </param>
+        /// <param name="sql">
+        ///     <see cref="StringBuilder"/> to add SQL commands to.
+        /// </param>
         protected virtual void ProcessStringLengthMinimumLength(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -218,6 +238,29 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
+        /// <summary>
+        ///     Creates SQL check constraint clause for the provided
+        ///     minimum length definition.
+        /// </summary>
+        /// <param name="property">
+        ///     Property to be examined.
+        /// </param>
+        /// <param name="memberInfo">
+        ///     <see cref="MemberInfo"/> of property to be examined.
+        /// </param>
+        /// <param name="tableName">
+        ///     Database table name.
+        /// </param>
+        /// <param name="columnName">
+        ///     Database table column name.
+        /// </param>
+        /// <param name="sql">
+        ///     <see cref="StringBuilder"/> to add SQL commands to.
+        /// </param>
+        /// <param name="minLength">
+        ///     Database table column's minimum length to be validated
+        ///     by table column check constraint.
+        /// </param>
         protected virtual void ProcessMinimumLengthInternal(
             IConventionProperty property,
             MemberInfo memberInfo,

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
@@ -17,10 +17,27 @@ namespace EFCore.CheckConstraints.Internal
     /// </summary>
     public class ValidationCheckConstraintConvention : IModelFinalizingConvention
     {
+        /// <summary>
+        ///     Default regular expression pattern string used for phone numbers.
+        /// </summary>
         public const string DefaultPhoneRegex = @"^[\d\s+-.()]*\d[\d\s+-.()]*((ext\.|ext|x)\s*\d+)?\s*$";
+
+        /// <summary>
+        ///     Default regular expression pattern string used for credit card numbers.
+        /// </summary>
         public const string DefaultCreditCardRegex = @"^[\d- ]*$";
+
+        /// <summary>
+        ///     Default regular expression pattern string used for e-mail addresses.
+        /// </summary>
         public const string DefaultEmailAddressRegex = @"^[^@]+@[^@]+$";
+
+        /// <summary>
+        ///     Default regular expression pattern string used for URLs.
+        /// </summary>
         public const string DefaultUrlAddressRegex = @"^(http://|https://|ftp://)";
+
+
 
         private readonly ISqlGenerationHelper _sqlGenerationHelper;
         private readonly IDatabaseProvider _databaseProvider;
@@ -29,6 +46,22 @@ namespace EFCore.CheckConstraints.Internal
         private readonly bool _supportsRegex;
         private readonly string _phoneRegex, _creditCardRegex, _emailAddressRegex, _urlRegex;
 
+
+        /// <summary>
+        ///     Creates a new <see cref="ValidationCheckConstraintConvention"/> object.
+        /// </summary>
+        /// <param name="options">
+        ///     Configures how validation check constraints will be created.
+        /// </param>
+        /// <param name="sqlGenerationHelper">
+        ///     Service to help with generation of SQL commands.
+        /// </param>
+        /// <param name="relationalTypeMappingSource">
+        ///     Relational type mapping interface for EF Core.
+        /// </param>
+        /// <param name="databaseProvider">
+        ///     The current database provider.
+        /// </param>
         public ValidationCheckConstraintConvention(
             ValidationCheckConstraintOptions options,
             ISqlGenerationHelper sqlGenerationHelper,
@@ -89,6 +122,27 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
+
+
+        /// <summary>
+        ///     Creates SQL check constraint clause for an entity property's
+        ///     <see cref="RangeAttribute"/> data annotation.
+        /// </summary>
+        /// <param name="property">
+        ///     Property to be examined.
+        /// </param>
+        /// <param name="memberInfo">
+        ///     <see cref="MemberInfo"/> of property to be examined.
+        /// </param>
+        /// <param name="tableName">
+        ///     Database table name.
+        /// </param>
+        /// <param name="columnName">
+        ///     Database table column name.
+        /// </param>
+        /// <param name="sql">
+        ///     <see cref="StringBuilder"/> to add SQL commands to.
+        /// </param>
         protected virtual void ProcessRange(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -119,6 +173,25 @@ namespace EFCore.CheckConstraints.Internal
             property.DeclaringEntityType.AddCheckConstraint(constraintName, sql.ToString());
         }
 
+        /// <summary>
+        ///     Creates SQL check constraint clause for an entity property's
+        ///     <see cref="MinLengthAttribute"/> data annotation.
+        /// </summary>
+        /// <param name="property">
+        ///     Property to be examined.
+        /// </param>
+        /// <param name="memberInfo">
+        ///     <see cref="MemberInfo"/> of property to be examined.
+        /// </param>
+        /// <param name="tableName">
+        ///     Database table name.
+        /// </param>
+        /// <param name="columnName">
+        ///     Database table column name.
+        /// </param>
+        /// <param name="sql">
+        ///     <see cref="StringBuilder"/> to add SQL commands to.
+        /// </param>
         protected virtual void ProcessMinLength(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -181,6 +254,25 @@ namespace EFCore.CheckConstraints.Internal
             property.DeclaringEntityType.AddCheckConstraint(constraintName, sql.ToString());
         }
 
+        /// <summary>
+        ///     Creates SQL check constraint clause for an entity property's
+        ///     <see cref="PhoneAttribute"/> data annotation.
+        /// </summary>
+        /// <param name="property">
+        ///     Property to be examined.
+        /// </param>
+        /// <param name="memberInfo">
+        ///     <see cref="MemberInfo"/> of property to be examined.
+        /// </param>
+        /// <param name="tableName">
+        ///     Database table name.
+        /// </param>
+        /// <param name="columnName">
+        ///     Database table column name.
+        /// </param>
+        /// <param name="sql">
+        ///     <see cref="StringBuilder"/> to add SQL commands to.
+        /// </param>
         protected virtual void ProcessPhoneNumber(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -196,6 +288,25 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
+        /// <summary>
+        ///     Creates SQL check constraint clause for an entity property's
+        ///     <see cref="CreditCardAttribute"/> data annotation.
+        /// </summary>
+        /// <param name="property">
+        ///     Property to be examined.
+        /// </param>
+        /// <param name="memberInfo">
+        ///     <see cref="MemberInfo"/> of property to be examined.
+        /// </param>
+        /// <param name="tableName">
+        ///     Database table name.
+        /// </param>
+        /// <param name="columnName">
+        ///     Database table column name.
+        /// </param>
+        /// <param name="sql">
+        ///     <see cref="StringBuilder"/> to add SQL commands to.
+        /// </param>
         protected virtual void ProcessCreditCard(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -211,6 +322,25 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
+        /// <summary>
+        ///     Creates SQL check constraint clause for an entity property's
+        ///     <see cref="EmailAddressAttribute"/> data annotation.
+        /// </summary>
+        /// <param name="property">
+        ///     Property to be examined.
+        /// </param>
+        /// <param name="memberInfo">
+        ///     <see cref="MemberInfo"/> of property to be examined.
+        /// </param>
+        /// <param name="tableName">
+        ///     Database table name.
+        /// </param>
+        /// <param name="columnName">
+        ///     Database table column name.
+        /// </param>
+        /// <param name="sql">
+        ///     <see cref="StringBuilder"/> to add SQL commands to.
+        /// </param>
         protected virtual void ProcessEmailAddress(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -226,6 +356,25 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
+        /// <summary>
+        ///     Creates SQL check constraint clause for an entity property's
+        ///     <see cref="UrlAttribute"/> data annotation.
+        /// </summary>
+        /// <param name="property">
+        ///     Property to be examined.
+        /// </param>
+        /// <param name="memberInfo">
+        ///     <see cref="MemberInfo"/> of property to be examined.
+        /// </param>
+        /// <param name="tableName">
+        ///     Database table name.
+        /// </param>
+        /// <param name="columnName">
+        ///     Database table column name.
+        /// </param>
+        /// <param name="sql">
+        ///     <see cref="StringBuilder"/> to add SQL commands to.
+        /// </param>
         protected virtual void ProcessUrl(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -241,6 +390,25 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
+        /// <summary>
+        ///     Creates SQL check constraint clause for an entity property's
+        ///     <see cref="RegularExpressionAttribute"/> data annotation.
+        /// </summary>
+        /// <param name="property">
+        ///     Property to be examined.
+        /// </param>
+        /// <param name="memberInfo">
+        ///     <see cref="MemberInfo"/> of property to be examined.
+        /// </param>
+        /// <param name="tableName">
+        ///     Database table name.
+        /// </param>
+        /// <param name="columnName">
+        ///     Database table column name.
+        /// </param>
+        /// <param name="sql">
+        ///     <see cref="StringBuilder"/> to add SQL commands to.
+        /// </param>
         protected virtual void ProcessRegularExpression(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -256,6 +424,23 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
+
+
+        /// <summary>
+        ///     Creates provider specific SQL constraint clause
+        ///     for evaluating the provided regular expression
+        ///     pattern string.
+        /// </summary>
+        /// <param name="columnName">
+        ///     Database table column name.
+        /// </param>
+        /// <param name="regex">
+        ///     Regular expression pattern string.
+        /// </param>
+        /// <returns>
+        ///     Provider specific SQL constraint clause
+        ///     for evaluating the provided regular expression.
+        /// </returns>
         protected virtual string GenerateRegexSql(string columnName, [RegexPattern] string regex)
             => string.Format(
                 _databaseProvider.Name switch
@@ -269,6 +454,11 @@ namespace EFCore.CheckConstraints.Internal
                     _ => throw new InvalidOperationException($"Provider {_databaseProvider.Name} doesn't support regular expressions")
                 }, _sqlGenerationHelper.DelimitIdentifier(columnName), regex);
 
+        /// <summary>
+        ///     <c>true</c> if the current database provider
+        ///     supports regular expression check constraints;
+        ///     <c>false</c> otherwise.
+        /// </summary>
         protected virtual bool SupportsRegex
             => _databaseProvider.Name switch
             {

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
@@ -39,7 +39,7 @@ namespace EFCore.CheckConstraints.Internal
             _databaseProvider = databaseProvider;
             _intTypeMapping = relationalTypeMappingSource.FindMapping(typeof(int));
 
-            _supportsRegex = SupportsRegex;
+            _supportsRegex = options.UseRegex && SupportsRegex;
             _phoneRegex = options.PhoneRegex ?? DefaultPhoneRegex;
             _creditCardRegex = options.CreditCardRegex ?? DefaultCreditCardRegex;
             _emailAddressRegex = options.EmailAddressRegex ?? DefaultEmailAddressRegex;

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
@@ -12,29 +12,14 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace EFCore.CheckConstraints.Internal
 {
-    /// <summary>
-    ///     A convention that creates check constraints for various validation attributes.
-    /// </summary>
     public class ValidationCheckConstraintConvention : IModelFinalizingConvention
     {
-        /// <summary>
-        ///     Default regular expression pattern string used for phone numbers.
-        /// </summary>
         public const string DefaultPhoneRegex = @"^[\d\s+-.()]*\d[\d\s+-.()]*((ext\.|ext|x)\s*\d+)?\s*$";
 
-        /// <summary>
-        ///     Default regular expression pattern string used for credit card numbers.
-        /// </summary>
         public const string DefaultCreditCardRegex = @"^[\d- ]*$";
 
-        /// <summary>
-        ///     Default regular expression pattern string used for e-mail addresses.
-        /// </summary>
         public const string DefaultEmailAddressRegex = @"^[^@]+@[^@]+$";
 
-        /// <summary>
-        ///     Default regular expression pattern string used for URLs.
-        /// </summary>
         public const string DefaultUrlAddressRegex = @"^(http://|https://|ftp://)";
 
         private readonly ISqlGenerationHelper _sqlGenerationHelper;
@@ -44,21 +29,6 @@ namespace EFCore.CheckConstraints.Internal
         private readonly bool _useRegex;
         private readonly string _phoneRegex, _creditCardRegex, _emailAddressRegex, _urlRegex;
 
-        /// <summary>
-        ///     Creates a new <see cref="ValidationCheckConstraintConvention"/> object.
-        /// </summary>
-        /// <param name="options">
-        ///     Configures how validation check constraints will be created.
-        /// </param>
-        /// <param name="sqlGenerationHelper">
-        ///     Service to help with generation of SQL commands.
-        /// </param>
-        /// <param name="relationalTypeMappingSource">
-        ///     Relational type mapping interface for EF Core.
-        /// </param>
-        /// <param name="databaseProvider">
-        ///     The current database provider.
-        /// </param>
         public ValidationCheckConstraintConvention(
             ValidationCheckConstraintOptions options,
             ISqlGenerationHelper sqlGenerationHelper,
@@ -76,7 +46,6 @@ namespace EFCore.CheckConstraints.Internal
             _urlRegex = options.UrlRegex ?? DefaultUrlAddressRegex;
         }
 
-        /// <inheritdoc />
         public virtual void ProcessModelFinalizing(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
         {
             var sql = new StringBuilder();
@@ -119,25 +88,6 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
-        /// <summary>
-        ///     Creates SQL check constraint clause for an entity property's
-        ///     <see cref="RangeAttribute"/> data annotation.
-        /// </summary>
-        /// <param name="property">
-        ///     Property to be examined.
-        /// </param>
-        /// <param name="memberInfo">
-        ///     <see cref="MemberInfo"/> of property to be examined.
-        /// </param>
-        /// <param name="tableName">
-        ///     Database table name.
-        /// </param>
-        /// <param name="columnName">
-        ///     Database table column name.
-        /// </param>
-        /// <param name="sql">
-        ///     <see cref="StringBuilder"/> to add SQL commands to.
-        /// </param>
         protected virtual void ProcessRange(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -168,25 +118,6 @@ namespace EFCore.CheckConstraints.Internal
             property.DeclaringEntityType.AddCheckConstraint(constraintName, sql.ToString());
         }
 
-        /// <summary>
-        ///     Creates SQL check constraint clause for an entity property's
-        ///     <see cref="MinLengthAttribute"/> data annotation.
-        /// </summary>
-        /// <param name="property">
-        ///     Property to be examined.
-        /// </param>
-        /// <param name="memberInfo">
-        ///     <see cref="MemberInfo"/> of property to be examined.
-        /// </param>
-        /// <param name="tableName">
-        ///     Database table name.
-        /// </param>
-        /// <param name="columnName">
-        ///     Database table column name.
-        /// </param>
-        /// <param name="sql">
-        ///     <see cref="StringBuilder"/> to add SQL commands to.
-        /// </param>
         protected virtual void ProcessMinLength(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -200,26 +131,6 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
-        /// <summary>
-        ///     Creates SQL check constraint clause for an entity property's
-        ///     <see cref="StringLengthAttribute.MinimumLength"/> data
-        ///     annotation attribute property.
-        /// </summary>
-        /// <param name="property">
-        ///     Property to be examined.
-        /// </param>
-        /// <param name="memberInfo">
-        ///     <see cref="MemberInfo"/> of property to be examined.
-        /// </param>
-        /// <param name="tableName">
-        ///     Database table name.
-        /// </param>
-        /// <param name="columnName">
-        ///     Database table column name.
-        /// </param>
-        /// <param name="sql">
-        ///     <see cref="StringBuilder"/> to add SQL commands to.
-        /// </param>
         protected virtual void ProcessStringLengthMinimumLength(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -233,29 +144,6 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
-        /// <summary>
-        ///     Creates SQL check constraint clause for the provided
-        ///     minimum length definition.
-        /// </summary>
-        /// <param name="property">
-        ///     Property to be examined.
-        /// </param>
-        /// <param name="memberInfo">
-        ///     <see cref="MemberInfo"/> of property to be examined.
-        /// </param>
-        /// <param name="tableName">
-        ///     Database table name.
-        /// </param>
-        /// <param name="columnName">
-        ///     Database table column name.
-        /// </param>
-        /// <param name="sql">
-        ///     <see cref="StringBuilder"/> to add SQL commands to.
-        /// </param>
-        /// <param name="minLength">
-        ///     Database table column's minimum length to be validated
-        ///     by table column check constraint.
-        /// </param>
         protected virtual void ProcessMinimumLengthInternal(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -292,25 +180,6 @@ namespace EFCore.CheckConstraints.Internal
             property.DeclaringEntityType.AddCheckConstraint(constraintName, sql.ToString());
         }
 
-        /// <summary>
-        ///     Creates SQL check constraint clause for an entity property's
-        ///     <see cref="PhoneAttribute"/> data annotation.
-        /// </summary>
-        /// <param name="property">
-        ///     Property to be examined.
-        /// </param>
-        /// <param name="memberInfo">
-        ///     <see cref="MemberInfo"/> of property to be examined.
-        /// </param>
-        /// <param name="tableName">
-        ///     Database table name.
-        /// </param>
-        /// <param name="columnName">
-        ///     Database table column name.
-        /// </param>
-        /// <param name="sql">
-        ///     <see cref="StringBuilder"/> to add SQL commands to.
-        /// </param>
         protected virtual void ProcessPhoneNumber(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -326,25 +195,6 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
-        /// <summary>
-        ///     Creates SQL check constraint clause for an entity property's
-        ///     <see cref="CreditCardAttribute"/> data annotation.
-        /// </summary>
-        /// <param name="property">
-        ///     Property to be examined.
-        /// </param>
-        /// <param name="memberInfo">
-        ///     <see cref="MemberInfo"/> of property to be examined.
-        /// </param>
-        /// <param name="tableName">
-        ///     Database table name.
-        /// </param>
-        /// <param name="columnName">
-        ///     Database table column name.
-        /// </param>
-        /// <param name="sql">
-        ///     <see cref="StringBuilder"/> to add SQL commands to.
-        /// </param>
         protected virtual void ProcessCreditCard(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -360,25 +210,6 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
-        /// <summary>
-        ///     Creates SQL check constraint clause for an entity property's
-        ///     <see cref="EmailAddressAttribute"/> data annotation.
-        /// </summary>
-        /// <param name="property">
-        ///     Property to be examined.
-        /// </param>
-        /// <param name="memberInfo">
-        ///     <see cref="MemberInfo"/> of property to be examined.
-        /// </param>
-        /// <param name="tableName">
-        ///     Database table name.
-        /// </param>
-        /// <param name="columnName">
-        ///     Database table column name.
-        /// </param>
-        /// <param name="sql">
-        ///     <see cref="StringBuilder"/> to add SQL commands to.
-        /// </param>
         protected virtual void ProcessEmailAddress(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -394,25 +225,6 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
-        /// <summary>
-        ///     Creates SQL check constraint clause for an entity property's
-        ///     <see cref="UrlAttribute"/> data annotation.
-        /// </summary>
-        /// <param name="property">
-        ///     Property to be examined.
-        /// </param>
-        /// <param name="memberInfo">
-        ///     <see cref="MemberInfo"/> of property to be examined.
-        /// </param>
-        /// <param name="tableName">
-        ///     Database table name.
-        /// </param>
-        /// <param name="columnName">
-        ///     Database table column name.
-        /// </param>
-        /// <param name="sql">
-        ///     <see cref="StringBuilder"/> to add SQL commands to.
-        /// </param>
         protected virtual void ProcessUrl(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -428,25 +240,6 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
-        /// <summary>
-        ///     Creates SQL check constraint clause for an entity property's
-        ///     <see cref="RegularExpressionAttribute"/> data annotation.
-        /// </summary>
-        /// <param name="property">
-        ///     Property to be examined.
-        /// </param>
-        /// <param name="memberInfo">
-        ///     <see cref="MemberInfo"/> of property to be examined.
-        /// </param>
-        /// <param name="tableName">
-        ///     Database table name.
-        /// </param>
-        /// <param name="columnName">
-        ///     Database table column name.
-        /// </param>
-        /// <param name="sql">
-        ///     <see cref="StringBuilder"/> to add SQL commands to.
-        /// </param>
         protected virtual void ProcessRegularExpression(
             IConventionProperty property,
             MemberInfo memberInfo,
@@ -462,21 +255,6 @@ namespace EFCore.CheckConstraints.Internal
             }
         }
 
-        /// <summary>
-        ///     Creates provider specific SQL constraint clause
-        ///     for evaluating the provided regular expression
-        ///     pattern string.
-        /// </summary>
-        /// <param name="columnName">
-        ///     Database table column name.
-        /// </param>
-        /// <param name="regex">
-        ///     Regular expression pattern string.
-        /// </param>
-        /// <returns>
-        ///     Provider specific SQL constraint clause
-        ///     for evaluating the provided regular expression.
-        /// </returns>
         protected virtual string GenerateRegexSql(string columnName, [RegexPattern] string regex)
             => string.Format(
                 _databaseProvider.Name switch
@@ -490,11 +268,6 @@ namespace EFCore.CheckConstraints.Internal
                     _ => throw new InvalidOperationException($"Provider {_databaseProvider.Name} doesn't support regular expressions")
                 }, _sqlGenerationHelper.DelimitIdentifier(columnName), regex);
 
-        /// <summary>
-        ///     <c>true</c> if the current database provider
-        ///     supports regular expression check constraints;
-        ///     <c>false</c> otherwise.
-        /// </summary>
         protected virtual bool SupportsRegex
             => _databaseProvider.Name switch
             {

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
@@ -37,15 +37,12 @@ namespace EFCore.CheckConstraints.Internal
         /// </summary>
         public const string DefaultUrlAddressRegex = @"^(http://|https://|ftp://)";
 
-
-
         private readonly ISqlGenerationHelper _sqlGenerationHelper;
         private readonly IDatabaseProvider _databaseProvider;
         private readonly RelationalTypeMapping _intTypeMapping;
 
         private readonly bool _useRegex;
         private readonly string _phoneRegex, _creditCardRegex, _emailAddressRegex, _urlRegex;
-
 
         /// <summary>
         ///     Creates a new <see cref="ValidationCheckConstraintConvention"/> object.
@@ -121,8 +118,6 @@ namespace EFCore.CheckConstraints.Internal
                 }
             }
         }
-
-
 
         /// <summary>
         ///     Creates SQL check constraint clause for an entity property's
@@ -466,8 +461,6 @@ namespace EFCore.CheckConstraints.Internal
                     GenerateRegexSql(columnName, pattern));
             }
         }
-
-
 
         /// <summary>
         ///     Creates provider specific SQL constraint clause

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptions.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptions.cs
@@ -31,8 +31,6 @@ namespace EFCore.CheckConstraints.Internal
             UrlRegex = copyFrom.UrlRegex;
         }
 
-
-
         /// <summary>
         ///     <c>true</c>, if validation check constraints based on regular
         ///     expressions should be used; <c>false</c> otherwise.
@@ -58,8 +56,6 @@ namespace EFCore.CheckConstraints.Internal
         ///     Regular expression pattern string to be used for validating URLs.
         /// </summary>
         public string UrlRegex { get; set; }
-
-
 
         /// <inheritdoc />
         public override bool Equals(object obj)

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptions.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptions.cs
@@ -13,12 +13,14 @@ namespace EFCore.CheckConstraints.Internal
 
         public ValidationCheckConstraintOptions(ValidationCheckConstraintOptions copyFrom)
         {
+            UseRegex = copyFrom.UseRegex;
             PhoneRegex = copyFrom.PhoneRegex;
             CreditCardRegex = copyFrom.CreditCardRegex;
             EmailAddressRegex = copyFrom.EmailAddressRegex;
             UrlRegex = copyFrom.UrlRegex;
         }
 
+        public bool UseRegex { get; set; }
         public string PhoneRegex { get; set; }
         public string CreditCardRegex { get; set; }
         public string EmailAddressRegex { get; set; }
@@ -29,12 +31,13 @@ namespace EFCore.CheckConstraints.Internal
 
         public bool Equals(ValidationCheckConstraintOptions other)
             => other != null
+                && UseRegex == other.UseRegex
                 && PhoneRegex == other.PhoneRegex
                 && CreditCardRegex == other.CreditCardRegex
                 && EmailAddressRegex == other.EmailAddressRegex
                 && UrlRegex == other.UrlRegex;
 
         public override int GetHashCode()
-            => HashCode.Combine(PhoneRegex, CreditCardRegex, EmailAddressRegex, UrlRegex);
+            => HashCode.Combine(UseRegex, PhoneRegex, CreditCardRegex, EmailAddressRegex, UrlRegex);
     }
 }

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptions.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptions.cs
@@ -5,12 +5,23 @@ using System;
 
 namespace EFCore.CheckConstraints.Internal
 {
+    /// <summary>
+    ///     Validation check constraint options.
+    /// </summary>
     public class ValidationCheckConstraintOptions : IEquatable<ValidationCheckConstraintOptions>
     {
-        public ValidationCheckConstraintOptions()
-        {
-        }
+        /// <summary>
+        ///     Creates a new <see cref="ValidationCheckConstraintOptions"/> object.
+        /// </summary>
+        public ValidationCheckConstraintOptions() {}
 
+        /// <summary>
+        ///     Creates a new <see cref="ValidationCheckConstraintOptions"/> object
+        ///     from a given <see cref="ValidationCheckConstraintOptions"/> object.
+        /// </summary>
+        /// <param name="copyFrom">
+        ///     <see cref="ValidationCheckConstraintOptions"/> object to copy.
+        /// </param>
         public ValidationCheckConstraintOptions(ValidationCheckConstraintOptions copyFrom)
         {
             UseRegex = copyFrom.UseRegex;
@@ -20,15 +31,41 @@ namespace EFCore.CheckConstraints.Internal
             UrlRegex = copyFrom.UrlRegex;
         }
 
+
+
+        /// <summary>
+        ///     <c>true</c>, if validation check constraints based on regular
+        ///     expressions should be used; <c>false</c> otherwise.
+        /// </summary>
         public bool UseRegex { get; set; }
+
+        /// <summary>
+        ///     Regular expression pattern string to be used for validating phone numbers.
+        /// </summary>
         public string PhoneRegex { get; set; }
+
+        /// <summary>
+        ///     Regular expression pattern string to be used for validating credit card numbers.
+        /// </summary>
         public string CreditCardRegex { get; set; }
+
+        /// <summary>
+        ///     Regular expression pattern string to be used for validating e-mail addresses.
+        /// </summary>
         public string EmailAddressRegex { get; set; }
+
+        /// <summary>
+        ///     Regular expression pattern string to be used for validating URLs.
+        /// </summary>
         public string UrlRegex { get; set; }
 
+
+
+        /// <inheritdoc />
         public override bool Equals(object obj)
             => obj is ValidationCheckConstraintOptions other && Equals(other);
 
+        /// <inheritdoc />
         public bool Equals(ValidationCheckConstraintOptions other)
             => other != null
                 && UseRegex == other.UseRegex
@@ -37,6 +74,7 @@ namespace EFCore.CheckConstraints.Internal
                 && EmailAddressRegex == other.EmailAddressRegex
                 && UrlRegex == other.UrlRegex;
 
+        /// <inheritdoc />
         public override int GetHashCode()
             => HashCode.Combine(UseRegex, PhoneRegex, CreditCardRegex, EmailAddressRegex, UrlRegex);
     }

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptions.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptions.cs
@@ -5,23 +5,10 @@ using System;
 
 namespace EFCore.CheckConstraints.Internal
 {
-    /// <summary>
-    ///     Validation check constraint options.
-    /// </summary>
     public class ValidationCheckConstraintOptions : IEquatable<ValidationCheckConstraintOptions>
     {
-        /// <summary>
-        ///     Creates a new <see cref="ValidationCheckConstraintOptions"/> object.
-        /// </summary>
         public ValidationCheckConstraintOptions() {}
 
-        /// <summary>
-        ///     Creates a new <see cref="ValidationCheckConstraintOptions"/> object
-        ///     from a given <see cref="ValidationCheckConstraintOptions"/> object.
-        /// </summary>
-        /// <param name="copyFrom">
-        ///     <see cref="ValidationCheckConstraintOptions"/> object to copy.
-        /// </param>
         public ValidationCheckConstraintOptions(ValidationCheckConstraintOptions copyFrom)
         {
             UseRegex = copyFrom.UseRegex;
@@ -31,37 +18,19 @@ namespace EFCore.CheckConstraints.Internal
             UrlRegex = copyFrom.UrlRegex;
         }
 
-        /// <summary>
-        ///     <c>true</c>, if validation check constraints based on regular
-        ///     expressions should be used; <c>false</c> otherwise.
-        /// </summary>
         public bool UseRegex { get; set; } = true;
 
-        /// <summary>
-        ///     Regular expression pattern string to be used for validating phone numbers.
-        /// </summary>
         public string PhoneRegex { get; set; }
 
-        /// <summary>
-        ///     Regular expression pattern string to be used for validating credit card numbers.
-        /// </summary>
         public string CreditCardRegex { get; set; }
 
-        /// <summary>
-        ///     Regular expression pattern string to be used for validating e-mail addresses.
-        /// </summary>
         public string EmailAddressRegex { get; set; }
 
-        /// <summary>
-        ///     Regular expression pattern string to be used for validating URLs.
-        /// </summary>
         public string UrlRegex { get; set; }
 
-        /// <inheritdoc />
         public override bool Equals(object obj)
             => obj is ValidationCheckConstraintOptions other && Equals(other);
 
-        /// <inheritdoc />
         public bool Equals(ValidationCheckConstraintOptions other)
             => other != null
                 && UseRegex == other.UseRegex
@@ -70,7 +39,6 @@ namespace EFCore.CheckConstraints.Internal
                 && EmailAddressRegex == other.EmailAddressRegex
                 && UrlRegex == other.UrlRegex;
 
-        /// <inheritdoc />
         public override int GetHashCode()
             => HashCode.Combine(UseRegex, PhoneRegex, CreditCardRegex, EmailAddressRegex, UrlRegex);
     }

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptions.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptions.cs
@@ -37,7 +37,7 @@ namespace EFCore.CheckConstraints.Internal
         ///     <c>true</c>, if validation check constraints based on regular
         ///     expressions should be used; <c>false</c> otherwise.
         /// </summary>
-        public bool UseRegex { get; set; }
+        public bool UseRegex { get; set; } = true;
 
         /// <summary>
         ///     Regular expression pattern string to be used for validating phone numbers.

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptionsBuilder.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptionsBuilder.cs
@@ -5,10 +5,17 @@ using JetBrains.Annotations;
 
 namespace EFCore.CheckConstraints.Internal
 {
+    /// <summary>
+    ///     Sets configuration options for <see cref="Microsoft.EntityFrameworkCore.CheckConstraintsExtensions"/> methods.
+    /// </summary>
     public class ValidationCheckConstraintOptionsBuilder
     {
         private readonly ValidationCheckConstraintOptions _options = new ValidationCheckConstraintOptions();
 
+
+        /// <summary>
+        ///     Current validation check constraint configuration.
+        /// </summary>
         public virtual ValidationCheckConstraintOptions Options => _options;
 
 
@@ -17,8 +24,8 @@ namespace EFCore.CheckConstraints.Internal
         ///     Enable or disable creation of regular expression constraints.
         /// </summary>
         /// <param name="useRegex">
-        ///     <c>true</c> if regular expression constraints should be created; else <c>false</c>.
-        ///     <c>true</c> is the default.
+        ///     <c>true</c> if regular expression constraints should be created; <c>false</c> otherwise.
+        ///     <c>true</c> is the default value.
         /// </param>
         /// <returns>
         ///     The current <see cref="ValidationCheckConstraintOptionsBuilder"/> object.

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptionsBuilder.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptionsBuilder.cs
@@ -11,24 +11,82 @@ namespace EFCore.CheckConstraints.Internal
 
         public virtual ValidationCheckConstraintOptions Options => _options;
 
+
+
+        /// <summary>
+        ///     Enable or disable creation of regular expression constraints.
+        /// </summary>
+        /// <param name="useRegex">
+        ///     <c>true</c> if regular expression constraints should be created; else <c>false</c>.
+        ///     <c>true</c> is the default.
+        /// </param>
+        /// <returns>
+        ///     The current <see cref="ValidationCheckConstraintOptionsBuilder"/> object.
+        /// </returns>
+        public virtual ValidationCheckConstraintOptionsBuilder UseRegex(bool useRegex)
+        {
+            _options.UseRegex = useRegex;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set regular expression pattern to match phone numbers against.
+        /// </summary>
+        /// <param name="phoneRegex">
+        ///     Regular expression pattern string to match phone numbers against.
+        ///     The default pattern string is @"^[\d\s+-.()]*\d[\d\s+-.()]*((ext\.|ext|x)\s*\d+)?\s*$".
+        /// </param>
+        /// <returns>
+        ///     The current <see cref="ValidationCheckConstraintOptionsBuilder"/> object.
+        /// </returns>
         public virtual ValidationCheckConstraintOptionsBuilder UsePhoneRegex([CanBeNull] string phoneRegex)
         {
             _options.PhoneRegex = phoneRegex;
             return this;
         }
 
+        /// <summary>
+        ///     Set regular expression pattern to match credit card numbers against.
+        /// </summary>
+        /// <param name="creditCardRegex">
+        ///     Regular expression pattern string to match credit card numbers against.
+        ///     The default pattern string is @"^[\d- ]*$".
+        /// </param>
+        /// <returns>
+        ///     The current <see cref="ValidationCheckConstraintOptionsBuilder"/> object.
+        /// </returns>
         public virtual ValidationCheckConstraintOptionsBuilder UseCreditCardRegex([CanBeNull] string creditCardRegex)
         {
             _options.CreditCardRegex = creditCardRegex;
             return this;
         }
 
+        /// <summary>
+        ///     Set regular expression pattern to match e-mail addresses against.
+        /// </summary>
+        /// <param name="emailRegex">
+        ///     Regular expression pattern string to match e-mail addresses against.
+        ///     The default pattern string is @"^[^@]+@[^@]+$".
+        /// </param>
+        /// <returns>
+        ///     The current <see cref="ValidationCheckConstraintOptionsBuilder"/> object.
+        /// </returns>
         public virtual ValidationCheckConstraintOptionsBuilder UseEmailRegex([CanBeNull] string emailRegex)
         {
             _options.EmailAddressRegex = emailRegex;
             return this;
         }
 
+        /// <summary>
+        ///     Set regular expression pattern to match URLs against.
+        /// </summary>
+        /// <param name="urlRegex">
+        ///     Regular expression pattern string to match URLs against.
+        ///     The default pattern string is @"^(http://|https://|ftp://)".
+        /// </param>
+        /// <returns>
+        ///     The current <see cref="ValidationCheckConstraintOptionsBuilder"/> object.
+        /// </returns>
         public virtual ValidationCheckConstraintOptionsBuilder UseUrlRegex([CanBeNull] string urlRegex)
         {
             _options.UrlRegex = urlRegex;

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptionsBuilder.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintOptionsBuilder.cs
@@ -12,13 +12,10 @@ namespace EFCore.CheckConstraints.Internal
     {
         private readonly ValidationCheckConstraintOptions _options = new ValidationCheckConstraintOptions();
 
-
         /// <summary>
         ///     Current validation check constraint configuration.
         /// </summary>
         public virtual ValidationCheckConstraintOptions Options => _options;
-
-
 
         /// <summary>
         ///     Enable or disable creation of regular expression constraints.

--- a/EFCore.CheckConstraints/ValidationCheckConstraintOptionsBuilder.cs
+++ b/EFCore.CheckConstraints/ValidationCheckConstraintOptionsBuilder.cs
@@ -1,9 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using EFCore.CheckConstraints.Internal;
 using JetBrains.Annotations;
 
-namespace EFCore.CheckConstraints.Internal
+namespace EFCore.CheckConstraints
 {
     /// <summary>
     ///     Sets configuration options for <see cref="Microsoft.EntityFrameworkCore.CheckConstraintsExtensions"/> methods.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ CREATE TABLE "Blogs" (
 
 Most of the attributes make use of database regular expressions. For SQL Server, this requires some initial setup - [follow these docs](https://www.red-gate.com/simple-talk/sql/t-sql-programming/tsql-regular-expression-workbench). Note that processing complex regular expressions does have a cost, so consider performance before turning these constraints on for write-intensive applications.
 
+To disable generating regular expression constraints from the corresponding data annotation attributes, set `UseRegex` validation check constraint option to `false`:
+
+```c#
+
+public class MyContext : DbContext
+{
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .UseSqlServer(...)
+            .UseValidationCheckConstraints(options => options.UseRegex(false));
+}
+```
+
 ## Enum constraints
 
 When you map a .NET enum to the database, by default that's done by storing the enum's underlying int in a plain old database int column (another common strategy is to map the string representation instead). Although the .NET enum has a constrained set of values which you've defined, on the database side there's nothing stopping anyone from inserting any value, including ones that are out of range.


### PR DESCRIPTION
Currently, `EFCore.CheckConstraints` is missing an option to ignore regular expressions.

Regular expressions add costs to SQL execution and burdon to administering SQL Server instances.

It is beneficial to restrict checking regular expressions in the business layer or front-end only.

This pull requests adds a Boolean `UseRegex` option to `ValidationCheckConstraintOptions`. If `true`, regular expression constraints will not be generated.
<br/>

Fixes #18.

See PR #23 for a merged branch containing this pull request and #21.