### PR TITLE
Constraint added for validating StringLengthAttribute.MinimumLength.

### DIFF
--- a/EFCore.CheckConstraints.Test/ValidationCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/ValidationCheckConstraintTest.cs
@@ -36,6 +36,16 @@ namespace EFCore.CheckConstraints.Test
         }
 
         [Fact]
+        public void StringLengthMinimumLength()
+        {
+            var entityType = BuildEntityType<Blog>();
+
+            var checkConstraint = Assert.Single(entityType.GetCheckConstraints(), c => c.Name == "CK_Blog_Required_MinLength");
+            Assert.NotNull(checkConstraint);
+            Assert.Equal("LEN([Required]) >= 1", checkConstraint.Sql);
+        }
+
+        [Fact]
         public virtual void Phone()
         {
             var entityType = BuildEntityType<Blog>();
@@ -103,6 +113,8 @@ namespace EFCore.CheckConstraints.Test
             public int Rating { get; set; }
             [MinLength(4)]
             public string Name { get; set; }
+            [StringLength(100, MinimumLength = 1)]
+            public string Required { get; set; }
             [Phone]
             public string PhoneNumber { get; set; }
             [CreditCard]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ public class Blog
     public int Rating { get; set; }
     [MinLength(4)]
     public string Name { get; set; }
+    [StringLength(100, MinimumLength = 1)]
+    public string Required { get; set; }
     [Phone]
     public string PhoneNumber { get; set; }
     [CreditCard]
@@ -58,6 +60,7 @@ CREATE TABLE "Blogs" (
     CONSTRAINT "CK_Blogs_CreditCard_CreditCard" CHECK ("CreditCard" ~ '^[\d- ]*$'),
     CONSTRAINT "CK_Blogs_Email_EmailAddress" CHECK ("Email" ~ '^[^@]+@[^@]+$'),
     CONSTRAINT "CK_Blogs_Name_MinLength" CHECK (LENGTH("Name") >= 4),
+    CONSTRAINT "CK_Blogs_Required_MinLength" CHECK (LENGTH("Required") >= 1),
     CONSTRAINT "CK_Blogs_PhoneNumber_Phone" CHECK ("PhoneNumber" ~ '^[\d\s+-.()]*\d[\d\s+-.()]*((ext\.|ext|x)\s*\d+)?\s*$'),
     CONSTRAINT "CK_Blogs_Rating_Range" CHECK ("Rating" >= 1 AND "Rating" <= 5),
     CONSTRAINT "CK_Blogs_StartsWithA_RegularExpression" CHECK ("StartsWithA" ~ '^A')


### PR DESCRIPTION
Currently, `EFCore.CheckConstraints` lacks an option to validate the [`StringLengthAttribute.MinimumLength`](https://docs.microsoft.com/dotnet/api/system.componentmodel.dataannotations.stringlengthattribute.minimumlength) data annotation attribute property.

The [`StringLengthAttribute`](https://docs.microsoft.com/dotnet/api/system.componentmodel.dataannotations.stringlengthattribute) combines both, [`MinLengthAttribute`](https://docs.microsoft.com/dotnet/api/system.componentmodel.dataannotations.minlengthattribute) and [`MaxLengthAttribute`](https://docs.microsoft.com/dotnet/api/system.componentmodel.dataannotations.maxlengthattribute) attributes. While the [`StringLengthAttribute.MaximumLength`](https://docs.microsoft.com/dotnet/api/system.componentmodel.dataannotations.stringlengthattribute.maximumlength) property is validated by Entity Framework (Core), it lacks validating the corresponding [`StringLengthAttribute.MinimumLength`](https://docs.microsoft.com/dotnet/api/system.componentmodel.dataannotations.stringlengthattribute.minimumlength) property.

This pull requests adds validation and constraint creation for the [`StringLengthAttribute.MinimumLength`](https://docs.microsoft.com/dotnet/api/system.componentmodel.dataannotations.stringlengthattribute.minimumlength) property.
<br/>

Fixes #19.

See PR #23 for a merged branch containing this pull request and #20.