### PR TITLE
Implement BETWEEN check for contiguous enum values

### DIFF
--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -28,6 +28,7 @@ public class EnumCheckConstraintConventionTest
     [InlineData(typeof(CustomerTypeSByte))]
     [InlineData(typeof(CustomerTypeShort))]
     [InlineData(typeof(CustomerTypeUShort))]
+    [InlineData(typeof(CustomerTypeOutOfOrder))]
     public void Simple(Type enumType)
     {
         var entityType = BuildEntityType(e => e.Property(enumType, "Type"));
@@ -243,6 +244,12 @@ public class EnumCheckConstraintConventionTest
         Standard = 14,
         Premium = 15,
         Enterprise = 16
+    }
+
+    private enum CustomerTypeOutOfOrder
+    {
+        Standard = 1,
+        Premium = 0
     }
 
     private enum EmptyEnum {}

--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -62,20 +62,6 @@ public class EnumCheckConstraintConventionTest
         Assert.Equal("[Type] BETWEEN 12 AND 16", checkConstraint.Sql);
     }
 
-    [Fact(Skip = "not ready yet")]
-    public void Complex_Range()
-    {
-        var entityType = BuildEntityType(e => e.Property<CustomerTypeWithMultipleRanges>("Type"));
-
-        Assert.Equal(3, entityType.GetCheckConstraints().Count());
-
-        //Assert.Contains();
-
-        //Assert.NotNull(checkConstraint);
-        //Assert.Equal("CK_Customer_Type_Enum", checkConstraint.Name);
-        //Assert.Equal("[Type] BETWEEN 12 AND 16", checkConstraint.Sql);
-    }
-
     [Fact]
     public void Value_converter()
     {
@@ -248,16 +234,6 @@ public class EnumCheckConstraintConventionTest
         Standard = 14,
         Premium = 15,
         Enterprise = 16
-    }
-
-    private enum CustomerTypeWithMultipleRanges
-    {
-        Basic = 12,
-        Shared = 13,
-        Standard = 16,
-        Premium = 18,
-        Enterprise = 19,
-        Enterprise2 = 20
     }
 
     private enum CustomerTypeOutOfOrder

--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -62,6 +62,20 @@ public class EnumCheckConstraintConventionTest
         Assert.Equal("[Type] BETWEEN 12 AND 16", checkConstraint.Sql);
     }
 
+    [Fact(Skip = "not ready yet")]
+    public void Complex_Range()
+    {
+        var entityType = BuildEntityType(e => e.Property<CustomerTypeWithMultipleRanges>("Type"));
+
+        Assert.Equal(3, entityType.GetCheckConstraints().Count());
+
+        //Assert.Contains();
+
+        //Assert.NotNull(checkConstraint);
+        //Assert.Equal("CK_Customer_Type_Enum", checkConstraint.Name);
+        //Assert.Equal("[Type] BETWEEN 12 AND 16", checkConstraint.Sql);
+    }
+
     [Fact]
     public void Value_converter()
     {
@@ -234,6 +248,16 @@ public class EnumCheckConstraintConventionTest
         Standard = 14,
         Premium = 15,
         Enterprise = 16
+    }
+
+    private enum CustomerTypeWithMultipleRanges
+    {
+        Basic = 12,
+        Shared = 13,
+        Standard = 16,
+        Premium = 18,
+        Enterprise = 19,
+        Enterprise2 = 20
     }
 
     private enum CustomerTypeOutOfOrder

--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -53,6 +53,17 @@ public class EnumCheckConstraintConventionTest
     }
 
     [Fact]
+    public void Simple_NegativeValues()
+    {
+        var entityType = BuildEntityType(e => e.Property<CustomerTypeNegative>("Type"));
+
+        var checkConstraint = Assert.Single(entityType.GetCheckConstraints());
+        Assert.NotNull(checkConstraint);
+        Assert.Equal("CK_Customer_Type_Enum", checkConstraint.Name);
+        Assert.Equal("[Type] BETWEEN -2 AND -1", checkConstraint.Sql);
+    }
+
+    [Fact]
     public void Simple_Range()
     {
         var entityType = BuildEntityType(e => e.Property<CustomerTypeStartingAfterZero>("Type"));
@@ -162,6 +173,12 @@ public class EnumCheckConstraintConventionTest
     {
         Standard = 0,
         Premium = 1
+    }
+
+    private enum CustomerTypeNegative
+    {
+        Standard = -1,
+        Premium = -2
     }
 
     private enum CustomerTypeWithDuplicates

--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -174,7 +174,7 @@ public class EnumCheckConstraintConventionTest
         Standard = 0,
         Premium = 1
     }
-    
+
     private enum CustomerTypeUInt : uint
     {
         Standard = 0,
@@ -192,7 +192,7 @@ public class EnumCheckConstraintConventionTest
         Standard = 0,
         Premium = 1
     }
-    
+
     // `nint` and `nuint` cannot be used as an enum base type from C#:
     // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/native-integers#miscellaneous
     //private enum CustomerTypeNInt : nint
@@ -206,7 +206,7 @@ public class EnumCheckConstraintConventionTest
     //    Standard = 0,
     //    Premium = 1
     //}
-    
+
     private enum CustomerTypeByte : byte
     {
         Standard = 0,

--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -171,18 +171,6 @@ public class EnumCheckConstraintConventionTest
         Premium = 1
     }
 
-    private enum CustomerTypeLong : long
-    {
-        Standard = 0,
-        Premium = 1
-    }
-
-    private enum CustomerTypeULong : ulong
-    {
-        Standard = 0,
-        Premium = 1
-    }
-
     // `nint` and `nuint` cannot be used as an enum base type from C#:
     // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/native-integers#miscellaneous
     //private enum CustomerTypeNInt : nint
@@ -196,6 +184,18 @@ public class EnumCheckConstraintConventionTest
     //    Standard = 0,
     //    Premium = 1
     //}
+
+    private enum CustomerTypeLong : long
+    {
+        Standard = 0,
+        Premium = 1
+    }
+
+    private enum CustomerTypeULong : ulong
+    {
+        Standard = 0,
+        Premium = 1
+    }
 
     private enum CustomerTypeByte : byte
     {

--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -21,6 +21,7 @@ public class EnumCheckConstraintConventionTest
 {
     [Theory]
     [InlineData(typeof(CustomerType))]
+    [InlineData(typeof(CustomerType?))]
     [InlineData(typeof(CustomerTypeUInt))]
     [InlineData(typeof(CustomerTypeLong))]
     [InlineData(typeof(CustomerTypeULong))]
@@ -59,17 +60,6 @@ public class EnumCheckConstraintConventionTest
         Assert.NotNull(checkConstraint);
         Assert.Equal("CK_Customer_Type_Enum", checkConstraint.Name);
         Assert.Equal("[Type] BETWEEN 12 AND 16", checkConstraint.Sql);
-    }
-
-    [Fact]
-    public void Nullable()
-    {
-        var entityType = BuildEntityType(e => e.Property<CustomerType?>("Type"));
-
-        var checkConstraint = Assert.Single(entityType.GetCheckConstraints());
-        Assert.NotNull(checkConstraint);
-        Assert.Equal("CK_Customer_Type_Enum", checkConstraint.Name);
-        Assert.Equal("[Type] BETWEEN 0 AND 1", checkConstraint.Sql);
     }
 
     [Fact]

--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -44,7 +44,7 @@ public class EnumCheckConstraintConventionTest
     [Fact]
     public void Simple_Range()
     {
-        var entityType = BuildEntityType(e => e.Property<CustomerTypeWithManyValues>("Type"));
+        var entityType = BuildEntityType(e => e.Property<CustomerTypeStartingAfterZero>("Type"));
 
         var checkConstraint = Assert.Single(entityType.GetCheckConstraints());
         Assert.NotNull(checkConstraint);
@@ -170,7 +170,7 @@ public class EnumCheckConstraintConventionTest
         Premium = 2
     }
 
-    private enum CustomerTypeWithManyValues
+    private enum CustomerTypeStartingAfterZero
     {
         Basic = 12,
         Shared = 13,

--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -27,7 +27,29 @@ public class EnumCheckConstraintConventionTest
         var checkConstraint = Assert.Single(entityType.GetCheckConstraints());
         Assert.NotNull(checkConstraint);
         Assert.Equal("CK_Customer_Type_Enum", checkConstraint.Name);
-        Assert.Equal("[Type] IN (0, 1)", checkConstraint.Sql);
+        Assert.Equal("[Type] BETWEEN 0 AND 1", checkConstraint.Sql);
+    }
+
+    [Fact]
+    public void Simple_NonContiguous()
+    {
+        var entityType = BuildEntityType(e => e.Property<NonContiguousCustomerType>("Type"));
+
+        var checkConstraint = Assert.Single(entityType.GetCheckConstraints());
+        Assert.NotNull(checkConstraint);
+        Assert.Equal("CK_Customer_Type_Enum", checkConstraint.Name);
+        Assert.Equal("[Type] IN (0, 2)", checkConstraint.Sql);
+    }
+
+    [Fact]
+    public void Simple_Range()
+    {
+        var entityType = BuildEntityType(e => e.Property<CustomerTypeWithManyValues>("Type"));
+
+        var checkConstraint = Assert.Single(entityType.GetCheckConstraints());
+        Assert.NotNull(checkConstraint);
+        Assert.Equal("CK_Customer_Type_Enum", checkConstraint.Name);
+        Assert.Equal("[Type] BETWEEN 12 AND 16", checkConstraint.Sql);
     }
 
     [Fact]
@@ -38,7 +60,7 @@ public class EnumCheckConstraintConventionTest
         var checkConstraint = Assert.Single(entityType.GetCheckConstraints());
         Assert.NotNull(checkConstraint);
         Assert.Equal("CK_Customer_Type_Enum", checkConstraint.Name);
-        Assert.Equal("[Type] IN (0, 1)", checkConstraint.Sql);
+        Assert.Equal("[Type] BETWEEN 0 AND 1", checkConstraint.Sql);
     }
 
     [Fact]
@@ -140,6 +162,21 @@ public class EnumCheckConstraintConventionTest
     {
         Standard = 0,
         Premium = 1
+    }
+
+    private enum NonContiguousCustomerType
+    {
+        Standard = 0,
+        Premium = 2
+    }
+
+    private enum CustomerTypeWithManyValues
+    {
+        Basic = 12,
+        Shared = 13,
+        Standard = 14,
+        Premium = 15,
+        Enterprise = 16
     }
 
     private enum EmptyEnum {}

--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -21,9 +21,9 @@ public class EnumCheckConstraintConventionTest
 {
     [Theory]
     [InlineData(typeof(CustomerType))]
+    [InlineData(typeof(CustomerTypeUInt))]
     [InlineData(typeof(CustomerTypeLong))]
     [InlineData(typeof(CustomerTypeULong))]
-    [InlineData(typeof(CustomerTypeUInt))]
     [InlineData(typeof(CustomerTypeByte))]
     [InlineData(typeof(CustomerTypeSByte))]
     [InlineData(typeof(CustomerTypeShort))]

--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -22,6 +22,7 @@ public class EnumCheckConstraintConventionTest
     [Theory]
     [InlineData(typeof(CustomerType))]
     [InlineData(typeof(CustomerType?))]
+    [InlineData(typeof(CustomerTypeWithDuplicates))]
     [InlineData(typeof(CustomerTypeUInt))]
     [InlineData(typeof(CustomerTypeLong))]
     [InlineData(typeof(CustomerTypeULong))]
@@ -159,6 +160,13 @@ public class EnumCheckConstraintConventionTest
 
     private enum CustomerType
     {
+        Standard = 0,
+        Premium = 1
+    }
+
+    private enum CustomerTypeWithDuplicates
+    {
+        Basic = 0,
         Standard = 0,
         Premium = 1
     }

--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -157,9 +157,7 @@ public class EnumCheckConstraintConventionTest
 
     #region Support
 
-    // ensure int is used explicitly
-    // ReSharper disable once EnumUnderlyingTypeIsInt
-    private enum CustomerType : int
+    private enum CustomerType
     {
         Standard = 0,
         Premium = 1
@@ -170,20 +168,6 @@ public class EnumCheckConstraintConventionTest
         Standard = 0,
         Premium = 1
     }
-
-    // `nint` and `nuint` cannot be used as an enum base type from C#:
-    // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/native-integers#miscellaneous
-    //private enum CustomerTypeNInt : nint
-    //{
-    //    Standard = (nint)0,
-    //    Premium = (nint)1
-    //}
-
-    //private enum CustomerTypeNUInt : nuint
-    //{
-    //    Standard = 0,
-    //    Premium = 1
-    //}
 
     private enum CustomerTypeLong : long
     {

--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -19,10 +19,18 @@ namespace EFCore.CheckConstraints.Test;
 
 public class EnumCheckConstraintConventionTest
 {
-    [Fact]
-    public void Simple()
+    [Theory]
+    [InlineData(typeof(CustomerType))]
+    [InlineData(typeof(CustomerTypeLong))]
+    [InlineData(typeof(CustomerTypeULong))]
+    [InlineData(typeof(CustomerTypeUInt))]
+    [InlineData(typeof(CustomerTypeByte))]
+    [InlineData(typeof(CustomerTypeSByte))]
+    [InlineData(typeof(CustomerTypeShort))]
+    [InlineData(typeof(CustomerTypeUShort))]
+    public void Simple(Type enumType)
     {
-        var entityType = BuildEntityType(e => e.Property<CustomerType>("Type"));
+        var entityType = BuildEntityType(e => e.Property(enumType, "Type"));
 
         var checkConstraint = Assert.Single(entityType.GetCheckConstraints());
         Assert.NotNull(checkConstraint);
@@ -158,7 +166,65 @@ public class EnumCheckConstraintConventionTest
 
     #region Support
 
-    private enum CustomerType
+    // ensure int is used explicitly
+    // ReSharper disable once EnumUnderlyingTypeIsInt
+    private enum CustomerType : int
+    {
+        Standard = 0,
+        Premium = 1
+    }
+    
+    private enum CustomerTypeUInt : uint
+    {
+        Standard = 0,
+        Premium = 1
+    }
+
+    private enum CustomerTypeLong : long
+    {
+        Standard = 0,
+        Premium = 1
+    }
+
+    private enum CustomerTypeULong : ulong
+    {
+        Standard = 0,
+        Premium = 1
+    }
+    
+    // `nint` and `nuint` cannot be used as an enum base type from C#:
+    // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/native-integers#miscellaneous
+    //private enum CustomerTypeNInt : nint
+    //{
+    //    Standard = (nint)0,
+    //    Premium = (nint)1
+    //}
+
+    //private enum CustomerTypeNUInt : nuint
+    //{
+    //    Standard = 0,
+    //    Premium = 1
+    //}
+    
+    private enum CustomerTypeByte : byte
+    {
+        Standard = 0,
+        Premium = 1
+    }
+
+    private enum CustomerTypeSByte : sbyte
+    {
+        Standard = 0,
+        Premium = 1
+    }
+
+    private enum CustomerTypeShort : short
+    {
+        Standard = 0,
+        Premium = 1
+    }
+
+    private enum CustomerTypeUShort : ushort
     {
         Standard = 0,
         Premium = 1

--- a/EFCore.CheckConstraints/EFCore.CheckConstraints.csproj
+++ b/EFCore.CheckConstraints/EFCore.CheckConstraints.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <VersionPrefix>7.0.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>

--- a/EFCore.CheckConstraints/Internal/DiscriminatorCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/DiscriminatorCheckConstraintConvention.cs
@@ -58,7 +58,7 @@ public class DiscriminatorCheckConstraintConvention : IModelFinalizingConvention
             }
 
             sql.Remove(sql.Length - 2, 2);
-            sql.Append(")");
+            sql.Append(')');
 
             var constraintName = $"CK_{tableIdentifier.Name}_Discriminator";
             rootEntityType.AddCheckConstraint(constraintName, sql.ToString());

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -124,7 +124,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
     }
 
     private static bool TryGetMinMax<T>(IEnumerable values, out T minValue, out T maxValue)
-        where T : INumber<T>, new()
+        where T : INumber<T>
     {
         var enumValues = values.Cast<T>().Distinct().ToList();
 

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
+using System.Collections;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -16,8 +14,6 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
 {
     private readonly IRelationalTypeMappingSource _typeMappingSource;
     private readonly ISqlGenerationHelper _sqlGenerationHelper;
-    private readonly Regex _castRegex = new("CAST\\((\\d+) AS (?:tinyint|smallint|bigint)\\)", RegexOptions.Compiled | RegexOptions.Singleline);
-    private readonly Regex _decimalRegex = new("(\\d+).0", RegexOptions.Compiled | RegexOptions.Singleline);
 
     public EnumCheckConstraintConvention(
         IRelationalTypeMappingSource typeMappingSource,
@@ -54,8 +50,8 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
                     continue;
                 }
 
-                var enumValues = Enum.GetValues(propertyType).Cast<object>().Select(typeMapping.GenerateSqlLiteral).ToList();
-                if (enumValues.Count == 0)
+                var values = Enum.GetValues(propertyType);
+                if (values.Length == 0)
                 {
                     continue;
                 }
@@ -64,7 +60,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
 
                 sql.Append(_sqlGenerationHelper.DelimitIdentifier(columnName));
 
-                if (TryParseMinAndMax(enumValues, out var minValue, out var maxValue))
+                if (TryParseContiguousRange(values, typeMapping, out var minValue, out var maxValue))
                 {
                     sql.Append(" BETWEEN ");
                     sql.Append(minValue);
@@ -74,7 +70,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
                 else
                 {
                     sql.Append(" IN (");
-                    foreach (var item in enumValues)
+                    foreach (var item in values.Cast<object>().Select(typeMapping.GenerateSqlLiteral))
                     {
                         sql.Append(item);
                         sql.Append(", ");
@@ -90,41 +86,24 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
         }
     }
 
-    // we use decimal explicitly here because decimal is a wider number type than all of the valid enum backing types
-    private bool TryParseMinAndMax(IReadOnlyCollection<string> enumValues, out decimal? minValue, out decimal? maxValue)
+    private static bool TryParseContiguousRange(
+        IEnumerable values,
+        CoreTypeMapping typeMapping,
+        out decimal minValue,
+        out decimal maxValue)
     {
-        var parsedEnumValues = enumValues.Select<string, decimal?>(
-                x =>
-                {
-                    decimal? result = null;
-
-                    if (decimal.TryParse(x, out var parsed))
-                    {
-                        result = parsed;
-                    }
-                    else if (_decimalRegex.Match(x) is { Success: true } decimalMatch)
-                    {
-                        result = decimal.Parse(decimalMatch.Groups[1].Value);
-                    }
-                    else if (_castRegex.Match(x) is { Success: true } castMatch)
-                    {
-                        result = decimal.Parse(castMatch.Groups[1].Value);
-                    }
-
-                    //decimal.Truncate is necessary because `ulong`s will include a fractional part
-                    return result.HasValue ? decimal.Truncate(result.Value) : null;
-                })
-            .ToList();
-
-        if (parsedEnumValues.Any(x => x is null))
+        if (typeMapping.Converter?.ProviderClrType == typeof(string))
         {
-            minValue = null;
-            maxValue = null;
+            minValue = 0;
+            maxValue = 0;
+
             return false;
         }
 
-        minValue = parsedEnumValues.Min();
-        maxValue = parsedEnumValues.Max();
+        var enumValues = values.Cast<object>().Select(Convert.ToDecimal).ToList();
+
+        minValue = enumValues.Min();
+        maxValue = enumValues.Max();
 
         return maxValue - minValue == enumValues.Count - 1;
     }

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -55,8 +55,8 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
 
             foreach (var property in entityType.GetDeclaredProperties())
             {
-                var typeMapping = (RelationalTypeMapping?)property.FindTypeMapping() ??
-                    _typeMappingSource.FindMapping((IProperty)property);
+                var typeMapping = (RelationalTypeMapping?)property.FindTypeMapping()
+                    ?? _typeMappingSource.FindMapping((IProperty)property);
                 var propertyType = Nullable.GetUnderlyingType(property.ClrType) ?? property.ClrType;
                 if (!propertyType.IsEnum
                     || typeMapping is null
@@ -88,8 +88,8 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
                     sql.Append(" IN (");
                     foreach (var item in values)
                     {
-                        sql.Append(typeMapping.GenerateSqlLiteral(item));
-                        sql.Append(", ");
+                        var value = typeMapping.GenerateSqlLiteral(item);
+                        sql.Append($"{value}, ");
                     }
 
                     sql.Remove(sql.Length - 2, 2);

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -45,7 +45,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
                 if (!propertyType.IsEnum
                     || typeMapping == null
                     || propertyType.IsDefined(typeof(FlagsAttribute), true)
-                    || property.GetColumnName(tableIdentifier) is not {} columnName)
+                    || property.GetColumnName(tableIdentifier) is not { } columnName)
                 {
                     continue;
                 }

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -80,9 +80,9 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
                 if (TryParseContiguousRange(typeMapping.Converter, values, out var minValue, out var maxValue))
                 {
                     sql.Append(" BETWEEN ");
-                    sql.Append(minValue);
+                    sql.Append(typeMapping.GenerateSqlLiteral(minValue));
                     sql.Append(" AND ");
-                    sql.Append(maxValue);
+                    sql.Append(typeMapping.GenerateSqlLiteral(maxValue));
                 }
                 else
                 {

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -126,9 +126,9 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
     }
 
     private static bool TryGetMinMax<T>(IEnumerable values, out T minValue, out T maxValue)
-        where T : IBinaryInteger<T>, new()
+        where T : INumber<T>, new()
     {
-        var enumValues = values.Cast<T>().ToList();
+        var enumValues = values.Cast<T>().Distinct().ToList();
 
         minValue = enumValues.Min()!;
         maxValue = enumValues.Max()!;

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -86,11 +86,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
         }
     }
 
-    private static bool TryParseContiguousRange(
-        IEnumerable values,
-        CoreTypeMapping typeMapping,
-        out decimal minValue,
-        out decimal maxValue)
+    private static bool TryParseContiguousRange(IEnumerable values, CoreTypeMapping typeMapping, out decimal minValue, out decimal maxValue)
     {
         if (typeMapping.Converter?.ProviderClrType == typeof(string))
         {
@@ -100,6 +96,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
             return false;
         }
 
+        // we use decimal explicitly here because decimal is a wider number type than all of the valid enum backing types
         var enumValues = values.Cast<object>().Select(Convert.ToDecimal).ToList();
 
         minValue = enumValues.Min();

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -31,9 +34,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
         typeof(decimal)
     };
 
-    public EnumCheckConstraintConvention(
-        IRelationalTypeMappingSource typeMappingSource,
-        ISqlGenerationHelper sqlGenerationHelper)
+    public EnumCheckConstraintConvention(IRelationalTypeMappingSource typeMappingSource, ISqlGenerationHelper sqlGenerationHelper)
     {
         _typeMappingSource = typeMappingSource;
         _sqlGenerationHelper = sqlGenerationHelper;
@@ -55,13 +56,12 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
 
             foreach (var property in entityType.GetDeclaredProperties())
             {
-                var typeMapping = (RelationalTypeMapping?)property.FindTypeMapping()
-                    ?? _typeMappingSource.FindMapping((IProperty)property);
+                var typeMapping = (RelationalTypeMapping?)property.FindTypeMapping() ?? _typeMappingSource.FindMapping((IProperty)property);
                 var propertyType = Nullable.GetUnderlyingType(property.ClrType) ?? property.ClrType;
                 if (!propertyType.IsEnum
                     || typeMapping is null
                     || propertyType.IsDefined(typeof(FlagsAttribute), true)
-                    || property.GetColumnName(tableIdentifier) is not { } columnName)
+                    || property.GetColumnName(tableIdentifier) is not {} columnName)
                 {
                     continue;
                 }
@@ -136,6 +136,6 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
 
         var enumValuesCount = (T)Convert.ChangeType(enumValues.Count, typeof(T));
 
-        return (maxValue - minValue) == (enumValuesCount + T.One);
+        return (maxValue - minValue) == (enumValuesCount - T.One);
     }
 }

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -115,12 +115,12 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
 
         var parameters = new object?[] { values, null, null };
 
-        var success = _supportedEnumValueTypes[underlyingType].Invoke(null, parameters)!;
+        var success = (bool)_supportedEnumValueTypes[underlyingType].Invoke(null, parameters)!;
 
-        minValue = parameters[1];
-        maxValue = parameters[2];
+        minValue = success ? parameters[1] : default;
+        maxValue = success ? parameters[2] : default;
 
-        return (bool)success;
+        return success;
     }
 
     private static bool TryGetMinMax<T>(IEnumerable values, out T minValue, out T maxValue)

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -56,8 +56,8 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
                     continue;
                 }
 
-                var values = Enum.GetValues(propertyType);
-                if (values.Length == 0)
+                var enumValues = Enum.GetValues(propertyType);
+                if (enumValues.Length == 0)
                 {
                     continue;
                 }
@@ -66,7 +66,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
 
                 sql.Append(_sqlGenerationHelper.DelimitIdentifier(columnName));
 
-                if (TryParseContiguousRange(typeMapping.Converter, values, out var minValue, out var maxValue))
+                if (TryParseContiguousRange(typeMapping.Converter, enumValues, out var minValue, out var maxValue))
                 {
                     sql.Append(" BETWEEN ");
                     sql.Append(typeMapping.GenerateSqlLiteral(minValue));
@@ -76,7 +76,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
                 else
                 {
                     sql.Append(" IN (");
-                    foreach (var item in values)
+                    foreach (var item in enumValues)
                     {
                         var value = typeMapping.GenerateSqlLiteral(item);
                         sql.Append($"{value}, ");

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -116,7 +116,6 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
 
         var parameters = new[] { values, minValue, maxValue };
 
-        // Use reflection to turn `TryGetMinMax` into a generic invocation using the underlying type of the num
         var success = GetType().GetTypeInfo().GetDeclaredMethod(nameof(TryGetMinMax))!.MakeGenericMethod(underlyingType)
             .Invoke(null, parameters)!;
 

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -63,7 +63,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
                     }
 
                     sql.Remove(sql.Length - 2, 2);
-                    sql.Append(")");
+                    sql.Append(')');
 
                     var constraintName = $"CK_{tableName}_{columnName}_Enum";
                     entityType.AddCheckConstraint(constraintName, sql.ToString());

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -74,7 +74,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
 
                 sql.Append(_sqlGenerationHelper.DelimitIdentifier(columnName));
 
-                if (TryParseContiguousRange(values, typeMapping, out var minValue, out var maxValue))
+                if (TryParseContiguousRange(typeMapping, values, out var minValue, out var maxValue))
                 {
                     sql.Append(" BETWEEN ");
                     sql.Append(minValue);
@@ -84,9 +84,9 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
                 else
                 {
                     sql.Append(" IN (");
-                    foreach (var item in values.Cast<object>().Select(typeMapping.GenerateSqlLiteral))
+                    foreach (var item in values)
                     {
-                        sql.Append(item);
+                        sql.Append(typeMapping.GenerateSqlLiteral(item));
                         sql.Append(", ");
                     }
 
@@ -100,7 +100,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
         }
     }
 
-    private bool TryParseContiguousRange(IEnumerable values, CoreTypeMapping typeMapping, out decimal minValue, out decimal maxValue)
+    private bool TryParseContiguousRange(CoreTypeMapping typeMapping, IEnumerable values, out object minValue, out object maxValue)
     {
         if (typeMapping.Converter?.ProviderClrType is null || !_knownTypes.Contains(typeMapping.Converter.ProviderClrType))
         {

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -43,7 +43,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
                     ?? _typeMappingSource.FindMapping((IProperty)property);
                 var propertyType = Nullable.GetUnderlyingType(property.ClrType) ?? property.ClrType;
                 if (!propertyType.IsEnum
-                    || typeMapping == null
+                    || typeMapping is null
                     || propertyType.IsDefined(typeof(FlagsAttribute), true)
                     || property.GetColumnName(tableIdentifier) is not { } columnName)
                 {

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -1,6 +1,3 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -34,7 +31,9 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
         typeof(decimal)
     };
 
-    public EnumCheckConstraintConvention(IRelationalTypeMappingSource typeMappingSource, ISqlGenerationHelper sqlGenerationHelper)
+    public EnumCheckConstraintConvention(
+        IRelationalTypeMappingSource typeMappingSource,
+        ISqlGenerationHelper sqlGenerationHelper)
     {
         _typeMappingSource = typeMappingSource;
         _sqlGenerationHelper = sqlGenerationHelper;
@@ -56,12 +55,13 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
 
             foreach (var property in entityType.GetDeclaredProperties())
             {
-                var typeMapping = (RelationalTypeMapping?)property.FindTypeMapping() ?? _typeMappingSource.FindMapping((IProperty)property);
+                var typeMapping = (RelationalTypeMapping?)property.FindTypeMapping() ??
+                    _typeMappingSource.FindMapping((IProperty)property);
                 var propertyType = Nullable.GetUnderlyingType(property.ClrType) ?? property.ClrType;
                 if (!propertyType.IsEnum
                     || typeMapping is null
                     || propertyType.IsDefined(typeof(FlagsAttribute), true)
-                    || property.GetColumnName(tableIdentifier) is not {} columnName)
+                    || property.GetColumnName(tableIdentifier) is not { } columnName)
                 {
                     continue;
                 }


### PR DESCRIPTION
Resolves https://github.com/efcore/EFCore.CheckConstraints/issues/3. Tries to check if the values of the enum type are ints and if they are in a contiguous range.

I'm sure this is a naive implementation, but `Enum.GetValues` returns a primitive `Array` type, so it's not fun to work with. I also added a few additional tests.