### PR TITLE
Cache enum check constraints

### DIFF
--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -106,6 +106,28 @@ public class EnumCheckConstraintConventionTest
     }
 
     [Fact]
+    public void Same_enum_twice_with_different_value_converters()
+    {
+        var entityType = BuildEntityType(e =>
+        {
+            e.Property<NonContiguousEnum>("Type1");
+            e.Property<NonContiguousEnum>("Type2").HasConversion<string>();
+        });
+
+        Assert.Collection(entityType.GetCheckConstraints().OrderBy(c => c.Name),
+            c =>
+            {
+                Assert.Equal("CK_Customer_Type1_Enum", c.Name);
+                Assert.Equal("[Type1] IN (0, 2, 3)", c.Sql);
+            },
+            c =>
+            {
+                Assert.Equal("CK_Customer_Type2_Enum", c.Name);
+                Assert.Equal("[Type2] IN (N'A', N'B', N'C')", c.Sql);
+            });
+    }
+
+    [Fact]
     public void Constraint_not_created_for_flags_enum()
     {
         var entityType = BuildEntityType(e => e.Property<FlagsEnum>("Type"));

--- a/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
+++ b/EFCore.CheckConstraints.Test/EnumCheckConstraintTest.cs
@@ -84,6 +84,28 @@ public class EnumCheckConstraintConventionTest
     }
 
     [Fact]
+    public void Same_enum_twice()
+    {
+        var entityType = BuildEntityType(e =>
+        {
+            e.Property<NonContiguousEnum>("Type1");
+            e.Property<NonContiguousEnum>("Type2");
+        });
+
+        Assert.Collection(entityType.GetCheckConstraints().OrderBy(c => c.Name),
+            c =>
+            {
+                Assert.Equal("CK_Customer_Type1_Enum", c.Name);
+                Assert.Equal("[Type1] IN (0, 2, 3)", c.Sql);
+            },
+            c =>
+            {
+                Assert.Equal("CK_Customer_Type2_Enum", c.Name);
+                Assert.Equal("[Type2] IN (0, 2, 3)", c.Sql);
+            });
+    }
+
+    [Fact]
     public void Constraint_not_created_for_flags_enum()
     {
         var entityType = BuildEntityType(e => e.Property<FlagsEnum>("Type"));

--- a/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/EnumCheckConstraintConvention.cs
@@ -62,7 +62,7 @@ public class EnumCheckConstraintConvention : IModelFinalizingConvention
                         continue;
                     }
 
-                    _cachedConstraints[typeMapping] = sql.ToString();
+                    _cachedConstraints[typeMapping] = constraintSql;
                 }
 
                 entityType.AddCheckConstraint(


### PR DESCRIPTION
@celluj34 here's another one for you. This caches most of the check constraint for a given enum type, so that when an enum type is used many times across a model (not uncommon) we only do the work once.