### PR TITLE
Improved switch statements based on the database provider name

### DIFF
--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
@@ -22,13 +22,10 @@ public class ValidationCheckConstraintConvention : IModelFinalizingConvention
 
     public const string DefaultUrlAddressRegex = @"^(http://|https://|ftp://)";
 
-    public const string SqlServerDatabaseProviderName = "MICROSOFT.ENTITYFRAMEWORKCORE.SQLSERVER";
-
-    public const string SqliteDatabaseProviderName = "MICROSOFT.ENTITYFRAMEWORKCORE.SQLITE";
-
-    public const string PostgreSqlDatabaseProviderName = "NPGSQL.ENTITYFRAMEWORKCORE.POSTGRESQL";
-
-    public const string MySqlDatabaseProviderName = "POMELO.ENTITYFRAMEWORKCORE.MYSQL";
+    public const string SqlServerDatabaseProviderName = "Microsoft.EntityFrameworkCore.SqlServer";
+    public const string SqliteDatabaseProviderName = "Microsoft.EntityFrameworkCore.Sqlite";
+    public const string PostgreSqlDatabaseProviderName = "Npgsql.EntityFrameworkCore.PostgreSQL";
+    public const string MySqlDatabaseProviderName = "Pomelo.EntityFrameworkCore.MySql";
 
     private readonly IRelationalTypeMappingSource _typeMappingSource;
     private readonly ISqlGenerationHelper _sqlGenerationHelper;
@@ -169,7 +166,7 @@ public class ValidationCheckConstraintConvention : IModelFinalizingConvention
         StringBuilder sql,
         int minLength)
     {
-        var lengthFunctionName = _databaseProvider.Name.ToUpper() switch
+        var lengthFunctionName = _databaseProvider.Name switch
         {
             SqlServerDatabaseProviderName => "LEN",
             SqliteDatabaseProviderName => "LENGTH",
@@ -274,7 +271,7 @@ public class ValidationCheckConstraintConvention : IModelFinalizingConvention
 
     protected virtual string GenerateRegexSql(string columnName, [RegexPattern] string regex)
         => string.Format(
-            _databaseProvider.Name.ToUpper() switch
+            _databaseProvider.Name switch
             {
                 // For SQL Server, requires setup:
                 // https://www.red-gate.com/simple-talk/sql/t-sql-programming/tsql-regular-expression-workbench/
@@ -286,7 +283,7 @@ public class ValidationCheckConstraintConvention : IModelFinalizingConvention
             }, _sqlGenerationHelper.DelimitIdentifier(columnName), regex);
 
     protected virtual bool SupportsRegex
-        => _databaseProvider.Name.ToUpper() switch
+        => _databaseProvider.Name switch
         {
             SqlServerDatabaseProviderName => true,
             SqliteDatabaseProviderName => true,

--- a/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
+++ b/EFCore.CheckConstraints/Internal/ValidationCheckConstraintConvention.cs
@@ -22,6 +22,14 @@ public class ValidationCheckConstraintConvention : IModelFinalizingConvention
 
     public const string DefaultUrlAddressRegex = @"^(http://|https://|ftp://)";
 
+    public const string SqlServerDatabaseProviderName = "MICROSOFT.ENTITYFRAMEWORKCORE.SQLSERVER";
+
+    public const string SqliteDatabaseProviderName = "MICROSOFT.ENTITYFRAMEWORKCORE.SQLITE";
+
+    public const string PostgreSqlDatabaseProviderName = "NPGSQL.ENTITYFRAMEWORKCORE.POSTGRESQL";
+
+    public const string MySqlDatabaseProviderName = "POMELO.ENTITYFRAMEWORKCORE.MYSQL";
+
     private readonly IRelationalTypeMappingSource _typeMappingSource;
     private readonly ISqlGenerationHelper _sqlGenerationHelper;
     private readonly IDatabaseProvider _databaseProvider;
@@ -161,12 +169,12 @@ public class ValidationCheckConstraintConvention : IModelFinalizingConvention
         StringBuilder sql,
         int minLength)
     {
-        var lengthFunctionName = _databaseProvider.Name switch
+        var lengthFunctionName = _databaseProvider.Name.ToUpper() switch
         {
-            "Microsoft.EntityFrameworkCore.SqlServer" => "LEN",
-            "Microsoft.EntityFrameworkCore.Sqlite" => "LENGTH",
-            "Npgsql.EntityFrameworkCore.PostgreSQL" => "LENGTH",
-            "Pomelo.EntityFrameworkCore.MySQL" => "LENGTH",
+            SqlServerDatabaseProviderName => "LEN",
+            SqliteDatabaseProviderName => "LENGTH",
+            PostgreSqlDatabaseProviderName => "LENGTH",
+            MySqlDatabaseProviderName => "LENGTH",
             _ => null
         };
 
@@ -266,24 +274,24 @@ public class ValidationCheckConstraintConvention : IModelFinalizingConvention
 
     protected virtual string GenerateRegexSql(string columnName, [RegexPattern] string regex)
         => string.Format(
-            _databaseProvider.Name switch
+            _databaseProvider.Name.ToUpper() switch
             {
                 // For SQL Server, requires setup:
                 // https://www.red-gate.com/simple-talk/sql/t-sql-programming/tsql-regular-expression-workbench/
-                "Microsoft.EntityFrameworkCore.SqlServer" => "dbo.RegexMatch('{1}', {0})",
-                "Microsoft.EntityFrameworkCore.Sqlite" => "{0} REGEXP '{1}'",
-                "Npgsql.EntityFrameworkCore.PostgreSQL" => "{0} ~ '{1}'",
-                "Pomelo.EntityFrameworkCore.MySQL" => "{0} REGEXP '{1}'",
+                SqlServerDatabaseProviderName => "dbo.RegexMatch('{1}', {0})",
+                SqliteDatabaseProviderName => "{0} REGEXP '{1}'",
+                PostgreSqlDatabaseProviderName => "{0} ~ '{1}'",
+                MySqlDatabaseProviderName => "{0} REGEXP '{1}'",
                 _ => throw new InvalidOperationException($"Provider {_databaseProvider.Name} doesn't support regular expressions")
             }, _sqlGenerationHelper.DelimitIdentifier(columnName), regex);
 
     protected virtual bool SupportsRegex
-        => _databaseProvider.Name switch
+        => _databaseProvider.Name.ToUpper() switch
         {
-            "Microsoft.EntityFrameworkCore.SqlServer" => true,
-            "Microsoft.EntityFrameworkCore.Sqlite" => true,
-            "Npgsql.EntityFrameworkCore.PostgreSQL" => true,
-            "Pomelo.EntityFrameworkCore.MySQL" => true,
+            SqlServerDatabaseProviderName => true,
+            SqliteDatabaseProviderName => true,
+            PostgreSqlDatabaseProviderName => true,
+            MySqlDatabaseProviderName => true,
             _ => false
         };
 }


### PR DESCRIPTION
Centralized the strings containing the names of the various database providers.
Changed the comparison with those name to be between uppercase strings to solve any problem about casing in the names.

Resolves #106